### PR TITLE
L1-L4 substrate elevation: honest README + L4 poller + L2 metamemory + L3 PoI closed loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > **Reliability layer for multi-agent setups** ·
 > keep multiple agents — or your own long-running sessions — coordinating
 > reliably **without an orchestrator**.
-> Cross-dialog contracts + drift detection + a 4-tier memory lifecycle.
+> Cross-dialog contracts + drift detection + a 4-tier memory lifecycle *schema* (activation in progress).
 > Plugin for Claude Code/Desktop · Cline · Cursor · Continue.dev · Zed.
 >
 > When an agent drifts from a rule you set, takes a shortcut you flagged,
@@ -97,9 +97,17 @@ retained behind an env flag for A/B.
 
 ### L3 tier promotion + Proof-of-Impact
 
-- daily idempotent tier-promotion driver (impact-based · LLM-free)
+- daily idempotent tier-promotion driver (impact-based · LLM-free) — *shipped + unit-tested; not yet scheduled in production*
 - PoI candidate emission at recall time + impact-weighted ranking boost
 - L1 session-summary overlay
+
+> **Activation status (honest):** the L3 lifecycle machinery — tier promotion,
+> `forget_at` archival, the promotion driver — is shipped and unit-tested, but
+> the production recall path does **not** yet promote tiers or apply `forget_at`
+> at query time (query ranking currently uses file-age `archived_at` decay + an
+> importance gate). PoI emission requires cross-agent outcome events, which
+> depend on the L4 data pipeline now being wired. Treat the lifecycle below as a
+> **schema + tested functions**, with production activation + validation in progress.
 
 ### Daemon hardening (P4–P9)
 
@@ -140,6 +148,11 @@ reinforce_count: 0                                  # access event counter
 
 Full design rationale in [`paper/LLM_WIKI2_FUSE_DESIGN.md`](paper/LLM_WIKI2_FUSE_DESIGN.md);
 implementation at [`recall.py:708+`](recall.py).
+
+> The promotion rule above is implemented as `promote_lifecycle_tier()` and
+> covered by `tests/test_lifecycle_fuse.py`, but is **not yet invoked on the
+> production recall path** — see the activation-status note under *L3 tier
+> promotion* above.
 
 ### Other v2.0.0 additions
 

--- a/metamemory/__init__.py
+++ b/metamemory/__init__.py
@@ -3,6 +3,7 @@ from metamemory.confidence import ConfidenceVector
 from metamemory.gap import GapStatement
 from metamemory.gap_detector import detect_gaps
 from metamemory.result import RecallResult
+from metamemory.builder import build_recall_result, format_metamemory_notice
 
 __all__ = [
     "ConfidenceVector",
@@ -10,4 +11,6 @@ __all__ = [
     "RecallResult",
     "calibration_score",
     "detect_gaps",
+    "build_recall_result",
+    "format_metamemory_notice",
 ]

--- a/metamemory/builder.py
+++ b/metamemory/builder.py
@@ -1,0 +1,130 @@
+"""build_recall_result · L2 integration glue (the missing wire).
+
+Turns the production recall path's match dicts into a metamemory `RecallResult`
+(per-match confidence + source trail + explicit gaps), so the subject LLM sees
+"compass has / does NOT have evidence for X" and stops hallucinating absence.
+
+Pluggable LLM backend (per handoff 2026-06-02):
+  · default `llm_backend=None`  -> fully deterministic · no LLM · data never
+    leaves the machine (black-box moat preserved). Always available, zero cost.
+  · optional callable `(query, matches, deterministic_gaps) -> list[GapStatement]`
+    -> local-qwen / cloud-gemini may refine gaps semantically. A backend that
+    raises is swallowed and we fall back to deterministic gaps — recall must
+    never break because an optional LLM is down.
+
+Per design doc 2026-05-29-compass-comprehensive-uplift-design.md §2.4.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from metamemory.confidence import ConfidenceVector
+from metamemory.gap import GapStatement
+from metamemory.gap_detector import detect_gaps
+from metamemory.calibration import calibration_score
+from metamemory.result import RecallResult
+
+_RECENCY_HORIZON_S = 30 * 86400  # linear decay to 0 over 30 days
+
+
+def _clamp01(x: float) -> float:
+    try:
+        x = float(x)
+    except (TypeError, ValueError):
+        return 0.0
+    return 0.0 if x < 0.0 else (1.0 if x > 1.0 else x)
+
+
+def _recency_factor(age_seconds: Any) -> float:
+    try:
+        age = float(age_seconds)
+    except (TypeError, ValueError):
+        return 0.0
+    if age <= 0:
+        return 1.0
+    return max(0.0, 1.0 - age / _RECENCY_HORIZON_S)
+
+
+def _source_diversity(matches: List[Dict[str, Any]]) -> float:
+    """Result-level diversity · distinct (type) over count · [0,1]."""
+    if not matches:
+        return 0.0
+    types = {(m.get("type") or "?") for m in matches}
+    return min(len(types) / len(matches), 1.0)
+
+
+def _evidence_count(match: Dict[str, Any], matches: List[Dict[str, Any]]) -> int:
+    """How many matches corroborate this one (share a non-empty concept)."""
+    concept = match.get("concept")
+    if not concept:
+        return 1
+    return sum(1 for m in matches if m.get("concept") == concept) or 1
+
+
+def _source_str(match: Dict[str, Any]) -> str:
+    path = match.get("path", "?")
+    type_ = match.get("type", "?")
+    age = match.get("age_str")
+    return f"{path} ({type_}" + (f", {age} old)" if age else ")")
+
+
+def build_recall_result(
+    query: str,
+    matches: List[Dict[str, Any]],
+    *,
+    history: Optional[List[Dict[str, Any]]] = None,
+    gap_threshold: float = 0.4,
+    llm_backend: Optional[Callable[[str, list, list], list]] = None,
+) -> RecallResult:
+    """Construct a metamemory RecallResult from real recall matches."""
+    matches = list(matches or [])
+    diversity = _source_diversity(matches)
+
+    confidence: List[ConfidenceVector] = []
+    source_trail: Dict[str, str] = {}
+    for m in matches:
+        mid = str(m.get("path") or m.get("id") or m.get("name") or "?")
+        confidence.append(ConfidenceVector(
+            match_id=mid,
+            score=_clamp01(m.get("score", 0.0)),
+            evidence_count=_evidence_count(m, matches),
+            recency_factor=_recency_factor(m.get("age_seconds", 0)),
+            source_diversity=diversity,
+        ))
+        source_trail[mid] = _source_str(m)
+
+    gaps = detect_gaps(query, matches, confidence, threshold=gap_threshold)
+
+    if llm_backend is not None:
+        try:
+            refined = llm_backend(query, matches, gaps)
+            if refined is not None:
+                gaps = list(refined)
+        except Exception:
+            # optional LLM must never break recall · keep deterministic gaps
+            pass
+
+    return RecallResult(
+        matches=matches,
+        confidence=confidence,
+        gaps=gaps,
+        source_trail=source_trail,
+        calibration_score=calibration_score(history or []),
+    )
+
+
+def format_metamemory_notice(rr: RecallResult) -> str:
+    """Render an LLM-facing notice for the subject agent · "" when evidence strong.
+
+    The hallucinate-absence cure: when compass has no/weak evidence, say so
+    explicitly so the agent does not fabricate a "prior finding". Empty string
+    when there is solid evidence (no noise injected into the agent's context).
+    """
+    if not rr.gaps:
+        return ""
+    lines = ["⚠️ metamemory · 自知层:"]
+    for g in rr.gaps:
+        lines.append(f"  · compass 对「{g.topic}」**没有可靠 evidence**({g.reason})")
+    lines.append("  → 不要凭空声称一条找不到出处的「既往结论」· "
+                 "如确需该信息,明说 compass 没存,而不是 hallucinate 一个。")
+    return "\n".join(lines)

--- a/ops/cross_agent_outcome_poller.py
+++ b/ops/cross_agent_outcome_poller.py
@@ -54,7 +54,9 @@ STATE_FILE = Path(os.environ.get(
     str(Path.home() / ".cache" / "compass" / "cross-agent-outcome-watermark.json"),
 ))
 PROJECTS_BASE = Path.home() / ".claude" / "projects"
-DEFAULT_PROJECT = os.environ.get("COMPASS_SOUL_INGEST_PROJECT", "C--Users-chunx")
+# Dedicated project dir by default · keeps platform cross-agent observations out
+# of the user's personal recall · L3 PoI emitter (P5) reads from here.
+DEFAULT_PROJECT = os.environ.get("COMPASS_SOUL_INGEST_PROJECT", "_l4_cross_agent")
 
 # drift aggregation
 DRIFT_MIN_SAMPLES = int(os.environ.get("COMPASS_SOUL_DRIFT_MIN_SAMPLES", "5"))

--- a/ops/cross_agent_outcome_poller.py
+++ b/ops/cross_agent_outcome_poller.py
@@ -59,6 +59,9 @@ DEFAULT_PROJECT = os.environ.get("COMPASS_SOUL_INGEST_PROJECT", "C--Users-chunx"
 # drift aggregation
 DRIFT_MIN_SAMPLES = int(os.environ.get("COMPASS_SOUL_DRIFT_MIN_SAMPLES", "5"))
 DRIFT_SUCCESS_FLOOR = float(os.environ.get("COMPASS_SOUL_DRIFT_FLOOR", "0.5"))
+# b2 (agent_tool_calls · 125k rows) is aggregated over a recent window into ONE
+# rollup file · never per-row (would flood recall).
+B2_WINDOW_HOURS = int(os.environ.get("COMPASS_SOUL_B2_WINDOW_HOURS", "24"))
 
 
 # ---------------------------------------------------------------- secret parse
@@ -209,6 +212,54 @@ thread_id: l4-cycle-outcomes
 
 
 # -------------------------------------------------------- drift aggregation
+def build_b2_rollup_session_md(signals: list, window_label: str = "24h") -> tuple:
+    """Per-agent drift rollup -> ONE session_*.md (anti-flooding).
+
+    agent_tool_calls is 125k+ rows · writing per-row files would drown recall.
+    Instead we summarise per-agent success rates for a recent window into a
+    single, stable-named file that is overwritten each run (always current; no
+    accumulation). Empty signals => an explicit stall marker (silence is signal).
+    """
+    filename = f"session_xrollup_agent_drift_{_slug(window_label, 12)}.md"
+    any_alert = any(s.get("alert") for s in signals)
+    drift = "yellow" if any_alert else "green"
+
+    if signals:
+        lines = []
+        for s in sorted(signals, key=lambda x: x.get("success_rate", 1.0)):
+            flag = "🔴" if s.get("alert") else "🟢"
+            lines.append(f"- {flag} `{s['agent_id']}` · success_rate "
+                         f"{s.get('success_rate', 0):.2f} · n={s.get('n', 0)}"
+                         + (" · **DRIFT**" if s.get("alert") else ""))
+        body_rows = "\n".join(lines)
+        desc = (f"{len(signals)} agents · "
+                f"{sum(1 for s in signals if s.get('alert'))} drift").replace("\n", " ")
+    else:
+        body_rows = "_(no agent tool activity in window · possible daemon stall)_"
+        desc = f"0 agents active in {window_label} · possible stall"
+
+    body = f"""---
+name: cross-agent drift rollup · {window_label}
+description: {desc[:200]}
+type: cross-agent-drift-rollup
+concept: l4-cross-agent-substrate
+drift: {drift}
+agent_type: platform-multi-agent
+window: {window_label}
+ingested_via: cross_agent_outcome_poller (L4 b2 rollup · anti-flood)
+thread_role: observation
+thread_id: l4-agent-drift-rollup
+---
+
+# Cross-agent drift rollup · last {window_label}
+
+Per-agent tool-call success rate (rolling window · low rate = persona/drift signal).
+
+{body_rows}
+"""
+    return filename, body
+
+
 def compute_drift_signal(agent_id: str, rows: list) -> dict:
     """Rolling success-rate signal for one agent across recent tool calls.
 
@@ -303,6 +354,30 @@ def _fetch_b2(conn, last_id: int, batch: int = BATCH) -> list:
     return [dict(zip(cols, r)) for r in cur.fetchall()]
 
 
+def _fetch_b2_signals(conn, hours: int = B2_WINDOW_HOURS) -> list:
+    """DB-side GROUP BY · per-agent success rate over a recent window.
+
+    Aggregates server-side (no 125k rows pulled into Python) · returns one signal
+    dict per active agent. This is the persona/drift fuel, not per-call files.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT agent_id, count(*), count(*) FILTER (WHERE success) "
+        "FROM agent_tool_calls WHERE ts > now() - make_interval(hours => %s) "
+        "GROUP BY agent_id ORDER BY 2 DESC", (hours,))
+    out = []
+    for agent_id, n, succ in cur.fetchall():
+        n = int(n or 0)
+        succ = int(succ or 0)
+        rate = (succ / n) if n else 1.0
+        out.append({
+            "agent_id": agent_id or "unknown", "n": n, "successes": succ,
+            "success_rate": rate,
+            "alert": (n >= DRIFT_MIN_SAMPLES and rate < DRIFT_SUCCESS_FLOOR),
+        })
+    return out
+
+
 def _fetch_a2(conn, last_ts, batch: int = BATCH) -> list:
     cols = ["cycle_id", "spec", "ship_status", "semantic_pass", "tests_pass",
             "actual_lines_added", "actual_lines_removed", "drift_ratio",
@@ -332,28 +407,20 @@ def main() -> int:
     mem_dir = PROJECTS_BASE / DEFAULT_PROJECT / "memory"
 
     written = 0
-    new_b2_id = wm["last_b2_id"]
     new_a2_ts = wm["last_a2_ts"]
-    by_agent: dict = {}
 
     try:
         with db_connection(cfg) as conn:
-            b2_rows = _fetch_b2(conn, wm["last_b2_id"])
+            # a2 · per-cycle (low volume · high value · watermark by created_at)
             a2_rows = _fetch_a2(conn, wm["last_a2_ts"])
+            # b2 · aggregated recent window -> ONE rollup (anti-flood)
+            signals = _fetch_b2_signals(conn, B2_WINDOW_HOURS)
     except Exception as e:
         sys.stderr.write(f"db poll failed · {type(e).__name__}: {str(e)[:200]}\n")
         return 1
 
     if not dry_run:
         mem_dir.mkdir(parents=True, exist_ok=True)
-
-    for row in b2_rows:
-        fn, content = build_b2_session_md(row)
-        if not dry_run:
-            (mem_dir / fn).write_text(content, encoding="utf-8")
-        written += 1
-        new_b2_id = max(new_b2_id, int(row["id"]))
-        by_agent.setdefault(row.get("agent_id") or "unknown", []).append(row)
 
     for row in a2_rows:
         fn, content = build_a2_session_md(row)
@@ -365,18 +432,20 @@ def main() -> int:
         if new_a2_ts is None or ca_iso > new_a2_ts:
             new_a2_ts = ca_iso
 
-    signals = [compute_drift_signal(a, rows) for a, rows in by_agent.items()]
+    # b2 rollup · single stable-named file overwritten each run (no accumulation)
+    roll_fn, roll_md = build_b2_rollup_session_md(signals, window_label=f"{B2_WINDOW_HOURS}h")
+    if not dry_run:
+        (mem_dir / roll_fn).write_text(roll_md, encoding="utf-8")
     alerts = [s for s in signals if s["alert"]]
 
     if not dry_run:
-        wm["last_b2_id"] = new_b2_id
         wm["last_a2_ts"] = new_a2_ts
         wm["ingested"] = int(wm.get("ingested", 0)) + written
         save_watermark(str(STATE_FILE), wm)
 
     print(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} · "
-          f"b2={len(b2_rows)} a2={len(a2_rows)} written={written} "
-          f"last_b2_id={new_b2_id} drift_alerts={len(alerts)}"
+          f"a2_new={len(a2_rows)} b2_agents={len(signals)} written={written} "
+          f"rollup={roll_fn} drift_alerts={len(alerts)}"
           + (" · DRY-RUN" if dry_run else ""))
     for s in alerts:
         print(f"  DRIFT ALERT · agent={s['agent_id']} "

--- a/ops/cross_agent_outcome_poller.py
+++ b/ops/cross_agent_outcome_poller.py
@@ -1,0 +1,388 @@
+"""compass · L4 cross-agent outcome poller.
+
+Polls two read-only tables on the platform DB (nautilus_production) and turns
+new rows into compass-recallable `session_*.md` observations, plus aggregate
+drift signals per agent. This is the L4 substrate data pipeline that feeds L3
+(Proof-of-Impact) and L1 (persona/drift) — without it, PoI emits 0 events.
+
+Source tables (compass_sub · GRANT SELECT only):
+  · engine_cycle_outcomes  (a2 · Soul engine cycle outcomes · PK cycle_id text)
+  · agent_tool_calls       (b2 · every agent tool dispatch · PK id bigint · 125k+ rows)
+
+Access path mirrors the verified probe: an ssh tunnel
+  ssh -L <localport>:localhost:5432 cloud
+then psycopg2 to 127.0.0.1:<localport>. compass_sub is not superuser (cannot set
+GUCs like lc_messages). We connect with client_encoding=UTF8 — the platform DB
+stores Chinese (UTF-8) data, so LATIN1 would raise UntranslatableCharacter on
+read; UTF8 carries both the data and server error messages correctly.
+
+Watermark (idempotent · incremental):
+  · b2 by integer id  (WHERE id > last_b2_id ORDER BY id ASC LIMIT batch)
+  · a2 by created_at  (WHERE created_at > last_a2_ts ORDER BY created_at ASC LIMIT batch)
+
+Direct file write (no MCP call) · cron/background-safe · the BGE daemon scans
+the memory dir anyway · matches platform_results_ingest_cron.py rationale.
+
+Credentials: password read ONLY from the secret file (key:value format) · never
+logged · never passed on a command line.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+# --------------------------------------------------------------------- config
+SECRET_FILE = os.environ.get(
+    "COMPASS_SOUL_DB_SECRET",
+    str(Path.home() / ".claude" / "plugins" / "nautilus-compass" / ".cache" / ".soul_db_secret"),
+)
+SSH_HOST = os.environ.get("COMPASS_SOUL_SSH_HOST", "cloud")
+LOCAL_PORT = int(os.environ.get("COMPASS_SOUL_LOCAL_PORT", "5439"))
+DB_USER = os.environ.get("COMPASS_SOUL_DB_USER", "compass_sub")
+BATCH = int(os.environ.get("COMPASS_SOUL_BATCH", "500"))
+
+STATE_FILE = Path(os.environ.get(
+    "COMPASS_SOUL_WATERMARK",
+    str(Path.home() / ".cache" / "compass" / "cross-agent-outcome-watermark.json"),
+))
+PROJECTS_BASE = Path.home() / ".claude" / "projects"
+DEFAULT_PROJECT = os.environ.get("COMPASS_SOUL_INGEST_PROJECT", "C--Users-chunx")
+
+# drift aggregation
+DRIFT_MIN_SAMPLES = int(os.environ.get("COMPASS_SOUL_DRIFT_MIN_SAMPLES", "5"))
+DRIFT_SUCCESS_FLOOR = float(os.environ.get("COMPASS_SOUL_DRIFT_FLOOR", "0.5"))
+
+
+# ---------------------------------------------------------------- secret parse
+def parse_secret(path: str) -> dict:
+    """Parse a `key: value` secret file into a lowercased dict.
+
+    Non `key:value` lines (e.g. a comment header) are ignored. Raises ValueError
+    if no password key is present (a poller without a password is useless).
+    """
+    cfg: dict = {}
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            m = re.match(r"^\s*([A-Za-z_]+)\s*:\s*(.+?)\s*$", line)
+            if m:
+                cfg[m.group(1).lower()] = m.group(2)
+    if "password" not in cfg:
+        raise ValueError(f"secret file {path} has no 'password' key")
+    return cfg
+
+
+# ---------------------------------------------------------------------- slug
+def _slug(s, n: int = 40) -> str:
+    out = "".join(c if (c.isascii() and (c.isalnum() or c in "-_")) else "_"
+                  for c in str(s)[:n])
+    return out.strip("_") or "x"
+
+
+def _ts_compact(value) -> str:
+    """datetime or ISO string -> YYYYMMDD-HHMM (UTC-local stamp from the row)."""
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except Exception:
+            return "00000000-0000"
+    return dt.strftime("%Y%m%d-%H%M")
+
+
+# ------------------------------------------------------- b2: agent_tool_calls
+def build_b2_session_md(row: dict) -> tuple[str, str]:
+    """agent_tool_calls row -> (filename, session_md). Deterministic filename."""
+    rid = row.get("id", "x")
+    agent_id = row.get("agent_id") or "unknown-agent"
+    tool_name = row.get("tool_name") or "unknown-tool"
+    success = bool(row.get("success"))
+    args_summary = (row.get("args_summary") or "")[:400]
+    output_summary = (row.get("output_summary") or "")[:600]
+    elapsed_ms = row.get("elapsed_ms")
+    phase = row.get("phase") or ""
+    ts = row.get("ts")
+
+    drift = "green" if success else "yellow"
+    filename = f"session_{_ts_compact(ts)}_xacall_{_slug(agent_id, 24)}_{rid}.md"
+    desc = (f"{agent_id} · {tool_name} · "
+            f"{'ok' if success else 'FAIL'}").replace("\n", " ")[:200]
+    ts_iso = ts.isoformat() if isinstance(ts, datetime) else str(ts)
+
+    body = f"""---
+name: cross-agent tool call · {agent_id} · {tool_name} · #{rid}
+description: {desc}
+type: cross-agent-tool-call
+concept: l4-cross-agent-substrate
+drift: {drift}
+agent_type: {agent_id}
+tool_name: {tool_name}
+success: {str(success).lower()}
+ingested_via: cross_agent_outcome_poller (L4 b2 agent_tool_calls)
+thread_role: observation
+thread_id: l4-agent-tool-calls
+---
+
+# Cross-agent tool call · {agent_id} · `{tool_name}` · #{rid}
+
+**ts**: {ts_iso}
+**agent**: `{agent_id}`
+**tool**: `{tool_name}`
+**success**: `{success}`
+**phase**: `{phase}`
+**elapsed_ms**: `{elapsed_ms}`
+**drift**: `{drift}`
+
+## args
+{args_summary or '_(none)_'}
+
+## output
+{output_summary or '_(none)_'}
+"""
+    return filename, body
+
+
+# ------------------------------------------------- a2: engine_cycle_outcomes
+def build_a2_session_md(row: dict) -> tuple[str, str]:
+    """engine_cycle_outcomes row -> (filename, session_md). Deterministic."""
+    cycle_id = row.get("cycle_id") or "cyc_unknown"
+    spec = (row.get("spec") or "")[:300]
+    ship_status = row.get("ship_status") or "unknown"
+    # keep raw (may be None) · None must not be read as a failed check (cry-wolf)
+    semantic_pass = row.get("semantic_pass")
+    tests_pass = row.get("tests_pass")
+    composite_score = row.get("composite_score")
+    drift_ratio = row.get("drift_ratio")
+    git_sha = row.get("git_sha") or ""
+    created_at = row.get("created_at")
+    goal_source = row.get("goal_source") or ""
+    fitness_delta = row.get("fitness_delta")
+
+    # ship_status is the primary health signal (sem/tests are often NULL in
+    # real data); an explicit False check is an additional negative signal.
+    SUCCESS = ("success", "shipped", "ship", "done", "ok", "passed")
+    healthy = (ship_status in SUCCESS
+               and semantic_pass is not False
+               and tests_pass is not False)
+    drift = "green" if healthy else "yellow"
+    filename = f"session_{_ts_compact(created_at)}_xcycle_{_slug(cycle_id, 32)}.md"
+    desc = (f"cycle {cycle_id} · {ship_status} · "
+            f"sem={semantic_pass} tests={tests_pass}").replace("\n", " ")[:200]
+    created_iso = created_at.isoformat() if isinstance(created_at, datetime) else str(created_at)
+
+    body = f"""---
+name: cross-agent cycle outcome · {cycle_id}
+description: {desc}
+type: cross-agent-cycle-outcome
+concept: l4-cross-agent-substrate
+drift: {drift}
+agent_type: platform-soul-engine
+ship_status: {ship_status}
+composite_score: {composite_score}
+ingested_via: cross_agent_outcome_poller (L4 a2 engine_cycle_outcomes)
+thread_role: observation
+thread_id: l4-cycle-outcomes
+---
+
+# Cross-agent cycle outcome · {cycle_id}
+
+**created_at**: {created_iso}
+**ship_status**: `{ship_status}`
+**semantic_pass**: `{semantic_pass}` · **tests_pass**: `{tests_pass}`
+**composite_score**: `{composite_score}` · **drift_ratio**: `{drift_ratio}`
+**fitness_delta**: `{fitness_delta}` · **goal_source**: `{goal_source}`
+**git_sha**: `{git_sha}`
+**drift**: `{drift}`
+
+## spec
+{spec or '_(none)_'}
+"""
+    return filename, body
+
+
+# -------------------------------------------------------- drift aggregation
+def compute_drift_signal(agent_id: str, rows: list) -> dict:
+    """Rolling success-rate signal for one agent across recent tool calls.
+
+    Alerts only when there are enough samples (>= DRIFT_MIN_SAMPLES) AND the
+    success rate falls below DRIFT_SUCCESS_FLOOR — deliberately conservative to
+    avoid the cry-wolf failure mode (n=1 never alerts).
+    """
+    n = len(rows)
+    successes = sum(1 for r in rows if bool(r.get("success")))
+    rate = (successes / n) if n else 1.0
+    alert = (n >= DRIFT_MIN_SAMPLES) and (rate < DRIFT_SUCCESS_FLOOR)
+    return {"agent_id": agent_id, "n": n, "successes": successes,
+            "success_rate": rate, "alert": alert}
+
+
+# -------------------------------------------------------------- watermark io
+def load_watermark(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        return {"last_b2_id": 0, "last_a2_ts": None, "ingested": 0}
+    try:
+        wm = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return {"last_b2_id": 0, "last_a2_ts": None, "ingested": 0}
+    wm.setdefault("last_b2_id", 0)
+    wm.setdefault("last_a2_ts", None)
+    wm.setdefault("ingested", 0)
+    return wm
+
+
+def save_watermark(path: str, wm: dict) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(wm, indent=2, default=str), encoding="utf-8")
+
+
+# ------------------------------------------------------------------ db layer
+@contextmanager
+def db_connection(cfg: dict, local_port: int = LOCAL_PORT):
+    """Open ssh tunnel + psycopg2 read-only connection · tear both down."""
+    import psycopg2  # local import · pure functions importable without driver
+
+    remote_host = cfg.get("host", "localhost")
+    remote_port = cfg.get("port", "5432")
+    dbname = cfg.get("dbname", "nautilus_production")
+
+    tunnel = subprocess.Popen(
+        ["ssh", "-N", "-o", "ExitOnForwardFailure=yes", "-o", "ConnectTimeout=10",
+         "-L", f"{local_port}:{remote_host}:{remote_port}", SSH_HOST],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    conn = None
+    try:
+        opened = False
+        for _ in range(60):
+            if tunnel.poll() is not None:
+                break
+            try:
+                with socket.create_connection(("127.0.0.1", local_port), timeout=0.5):
+                    opened = True
+                    break
+            except OSError:
+                time.sleep(0.25)
+        if not opened:
+            err = tunnel.stderr.read().decode("utf-8", "replace") if tunnel.stderr else ""
+            raise RuntimeError(f"ssh tunnel did not open: {err[:200]}")
+        conn = psycopg2.connect(
+            host="127.0.0.1", port=local_port, dbname=dbname,
+            user=DB_USER, password=cfg["password"],
+            connect_timeout=10, client_encoding="UTF8")
+        conn.set_session(readonly=True, autocommit=True)
+        yield conn
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        tunnel.terminate()
+        try:
+            tunnel.wait(timeout=5)
+        except Exception:
+            tunnel.kill()
+
+
+def _fetch_b2(conn, last_id: int, batch: int = BATCH) -> list:
+    cols = ["id", "agent_id", "tool_name", "args_summary", "output_summary",
+            "success", "elapsed_ms", "ts", "phase"]
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT {', '.join(cols)} FROM agent_tool_calls "
+        "WHERE id > %s ORDER BY id ASC LIMIT %s", (last_id, batch))
+    return [dict(zip(cols, r)) for r in cur.fetchall()]
+
+
+def _fetch_a2(conn, last_ts, batch: int = BATCH) -> list:
+    cols = ["cycle_id", "spec", "ship_status", "semantic_pass", "tests_pass",
+            "actual_lines_added", "actual_lines_removed", "drift_ratio",
+            "composite_score", "git_sha", "created_at", "goal_source", "fitness_delta"]
+    cur = conn.cursor()
+    if last_ts:
+        cur.execute(
+            f"SELECT {', '.join(cols)} FROM engine_cycle_outcomes "
+            "WHERE created_at > %s ORDER BY created_at ASC LIMIT %s", (last_ts, batch))
+    else:
+        cur.execute(
+            f"SELECT {', '.join(cols)} FROM engine_cycle_outcomes "
+            "ORDER BY created_at ASC LIMIT %s", (batch,))
+    return [dict(zip(cols, r)) for r in cur.fetchall()]
+
+
+# ----------------------------------------------------------------------- main
+def main() -> int:
+    try:
+        cfg = parse_secret(SECRET_FILE)
+    except (FileNotFoundError, ValueError) as e:
+        sys.stderr.write(f"secret unavailable · {e}\n")
+        return 0  # not an error · credential simply not provisioned here
+
+    dry_run = "--dry-run" in sys.argv
+    wm = load_watermark(str(STATE_FILE))
+    mem_dir = PROJECTS_BASE / DEFAULT_PROJECT / "memory"
+
+    written = 0
+    new_b2_id = wm["last_b2_id"]
+    new_a2_ts = wm["last_a2_ts"]
+    by_agent: dict = {}
+
+    try:
+        with db_connection(cfg) as conn:
+            b2_rows = _fetch_b2(conn, wm["last_b2_id"])
+            a2_rows = _fetch_a2(conn, wm["last_a2_ts"])
+    except Exception as e:
+        sys.stderr.write(f"db poll failed · {type(e).__name__}: {str(e)[:200]}\n")
+        return 1
+
+    if not dry_run:
+        mem_dir.mkdir(parents=True, exist_ok=True)
+
+    for row in b2_rows:
+        fn, content = build_b2_session_md(row)
+        if not dry_run:
+            (mem_dir / fn).write_text(content, encoding="utf-8")
+        written += 1
+        new_b2_id = max(new_b2_id, int(row["id"]))
+        by_agent.setdefault(row.get("agent_id") or "unknown", []).append(row)
+
+    for row in a2_rows:
+        fn, content = build_a2_session_md(row)
+        if not dry_run:
+            (mem_dir / fn).write_text(content, encoding="utf-8")
+        written += 1
+        ca = row.get("created_at")
+        ca_iso = ca.isoformat() if isinstance(ca, datetime) else str(ca)
+        if new_a2_ts is None or ca_iso > new_a2_ts:
+            new_a2_ts = ca_iso
+
+    signals = [compute_drift_signal(a, rows) for a, rows in by_agent.items()]
+    alerts = [s for s in signals if s["alert"]]
+
+    if not dry_run:
+        wm["last_b2_id"] = new_b2_id
+        wm["last_a2_ts"] = new_a2_ts
+        wm["ingested"] = int(wm.get("ingested", 0)) + written
+        save_watermark(str(STATE_FILE), wm)
+
+    print(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} · "
+          f"b2={len(b2_rows)} a2={len(a2_rows)} written={written} "
+          f"last_b2_id={new_b2_id} drift_alerts={len(alerts)}"
+          + (" · DRY-RUN" if dry_run else ""))
+    for s in alerts:
+        print(f"  DRIFT ALERT · agent={s['agent_id']} "
+              f"success_rate={s['success_rate']:.2f} n={s['n']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -73,21 +73,38 @@ def main() -> int:
 
     actors = sorted({c.get("actor") for c in pending if c.get("actor")})
     since = min(str(c.get("ts", "")) for c in pending)
+    memory_root = Path(MEMORY_ROOT) if MEMORY_ROOT else None
 
+    outcomes: list = []
+
+    # Platform outcomes (agent_tool_calls) · credits platform agents · graceful
+    # skip when the DB secret is not provisioned (path B works without it).
     try:
         cfg = _poller.parse_secret(_poller.SECRET_FILE)
+        with _poller.db_connection(cfg) as conn:
+            outcomes += _fetch_outcomes_for(conn, actors, since, WINDOW_S)
     except (FileNotFoundError, ValueError) as e:
-        sys.stderr.write(f"secret unavailable · {e}\n")
+        sys.stderr.write(f"platform outcomes skipped · secret unavailable · {e}\n")
+    except Exception as e:
+        sys.stderr.write(f"platform outcome fetch failed · {type(e).__name__}: {str(e)[:200]}\n")
+
+    # Path B · local outcomes from the user's own session_*.md drift signal ·
+    # lets local (anon/unknown) recalls self-settle without any platform agent.
+    n_local = 0
+    if memory_root and os.environ.get("COMPASS_POI_LOCAL_OUTCOMES", "1") != "0":
+        try:
+            from proof import local_outcomes as _LO
+            for actor in actors:
+                lo = _LO.local_outcomes(memory_root, actor, since_iso=since)
+                outcomes += lo
+                n_local += len(lo)
+        except Exception as e:
+            sys.stderr.write(f"local outcomes skipped · {type(e).__name__}: {str(e)[:160]}\n")
+
+    if not outcomes:
+        print("no outcomes (platform + local) · nothing to settle yet")
         return 0
 
-    try:
-        with _poller.db_connection(cfg) as conn:
-            outcomes = _fetch_outcomes_for(conn, actors, since, WINDOW_S)
-    except Exception as e:
-        sys.stderr.write(f"outcome fetch failed · {type(e).__name__}: {str(e)[:200]}\n")
-        return 1
-
-    memory_root = Path(MEMORY_ROOT) if MEMORY_ROOT else None
     work_keys = set() if dry_run else settled_keys
     res = R.reconcile(pending, outcomes, settled_keys=work_keys,
                       window_seconds=WINDOW_S, memory_root=memory_root,
@@ -98,7 +115,7 @@ def main() -> int:
 
     print(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} · "
           f"candidates={len(candidates)} pending={len(pending)} "
-          f"actors={len(actors)} outcomes={len(outcomes)} "
+          f"actors={len(actors)} outcomes={len(outcomes)} (local={n_local}) "
           f"settled={res['settled']} no_match={res['skipped_no_match']}"
           + (" · DRY-RUN" if dry_run else ""))
     return 0

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -1,0 +1,108 @@
+"""compass · L3 PoI reconcile runner · closes the recursive loop.
+
+Joins recall-time PoI candidates (poi_candidates.jsonl · written by the daemon
+recall path) with real agent outcomes (agent_tool_calls · via the same ssh
+tunnel + read-only compass_sub creds as the cross-agent poller) and settles each
+match into a full PoI event that credits cumulative_impact on the cited memory.
+
+  recall surfaces memory → candidate → agent acts → outcome (L4) → reconcile →
+  cumulative_impact credited → recall boost_top_k uses it next time.
+
+Pure join logic lives in proof/poi_reconciler.py (unit-tested). This file is the
+runtime glue: load candidates, fetch outcomes for the candidates' actors, run
+the reconcile, persist the settled-key state. Manual/cron-safe · idempotent ·
+NO LLM. Reuses ops/cross_agent_outcome_poller.py for the DB connection.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+# reuse the poller's verified DB connection + secret parsing
+_spec = importlib.util.spec_from_file_location(
+    "cross_agent_outcome_poller", _HERE / "cross_agent_outcome_poller.py")
+_poller = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_poller)
+
+sys.path.insert(0, str(_HERE.parent))
+from proof import poi_reconciler as R  # noqa: E402
+
+CANDIDATE_DIR = Path(os.environ.get(
+    "COMPASS_POI_CACHE_DIR",
+    str(Path.home() / ".claude" / "plugins" / "nautilus-compass" / ".cache")))
+WINDOW_S = int(os.environ.get("COMPASS_POI_RECONCILE_WINDOW_S", str(R.DEFAULT_WINDOW_S)))
+# memory_root: where cited memory files live (to update their frontmatter)
+MEMORY_ROOT = os.environ.get("COMPASS_POI_MEMORY_ROOT", "")
+
+
+def _fetch_outcomes_for(conn, actors: list, since_iso: str, window_s: int) -> list:
+    """agent_tool_calls outcomes for the candidate actors, from since_iso forward."""
+    if not actors:
+        return []
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT agent_id, success, ts FROM agent_tool_calls "
+        "WHERE agent_id = ANY(%s) AND ts > %s ORDER BY ts ASC",
+        (list(actors), since_iso))
+    return [{"agent_id": r[0], "success": r[1],
+             "ts": r[2].isoformat() if hasattr(r[2], "isoformat") else str(r[2])}
+            for r in cur.fetchall()]
+
+
+def main() -> int:
+    dry_run = "--dry-run" in sys.argv
+    cand_path = CANDIDATE_DIR / R.CANDIDATE_SIDECAR
+    settled_path = CANDIDATE_DIR / R.SETTLED_STATE
+
+    candidates = R.load_candidates(cand_path)
+    if not candidates:
+        print(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} · "
+              f"no candidates at {cand_path} · nothing to reconcile")
+        return 0
+
+    settled_keys = R.load_settled(settled_path)
+    pending = [c for c in candidates if R.candidate_key(c) not in settled_keys]
+    if not pending:
+        print(f"all {len(candidates)} candidates already settled")
+        return 0
+
+    actors = sorted({c.get("actor") for c in pending if c.get("actor")})
+    since = min(str(c.get("ts", "")) for c in pending)
+
+    try:
+        cfg = _poller.parse_secret(_poller.SECRET_FILE)
+    except (FileNotFoundError, ValueError) as e:
+        sys.stderr.write(f"secret unavailable · {e}\n")
+        return 0
+
+    try:
+        with _poller.db_connection(cfg) as conn:
+            outcomes = _fetch_outcomes_for(conn, actors, since, WINDOW_S)
+    except Exception as e:
+        sys.stderr.write(f"outcome fetch failed · {type(e).__name__}: {str(e)[:200]}\n")
+        return 1
+
+    memory_root = Path(MEMORY_ROOT) if MEMORY_ROOT else None
+    work_keys = set() if dry_run else settled_keys
+    res = R.reconcile(pending, outcomes, settled_keys=work_keys,
+                      window_seconds=WINDOW_S, memory_root=memory_root,
+                      cache_dir=(CANDIDATE_DIR if not dry_run else Path(os.devnull).parent))
+
+    if not dry_run:
+        R.save_settled(settled_path, settled_keys)
+
+    print(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} · "
+          f"candidates={len(candidates)} pending={len(pending)} "
+          f"actors={len(actors)} outcomes={len(outcomes)} "
+          f"settled={res['settled']} no_match={res['skipped_no_match']}"
+          + (" · DRY-RUN" if dry_run else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -106,9 +106,13 @@ def main() -> int:
         return 0
 
     work_keys = set() if dry_run else settled_keys
-    res = R.reconcile(pending, outcomes, settled_keys=work_keys,
-                      window_seconds=WINDOW_S, memory_root=memory_root,
-                      cache_dir=(CANDIDATE_DIR if not dry_run else Path(os.devnull).parent))
+    try:
+        res = R.reconcile(pending, outcomes, settled_keys=work_keys,
+                          window_seconds=WINDOW_S, memory_root=memory_root,
+                          cache_dir=(CANDIDATE_DIR if not dry_run else Path(os.devnull).parent))
+    except Exception as e:
+        sys.stderr.write(f"reconcile failed · {type(e).__name__}: {str(e)[:200]}\n")
+        return 1
 
     if not dry_run:
         R.save_settled(settled_path, settled_keys)

--- a/ops/setup-l4-poller-task.ps1
+++ b/ops/setup-l4-poller-task.ps1
@@ -1,0 +1,50 @@
+# compass · L4 cross-agent outcome poller · Windows Task Scheduler registration
+# ---------------------------------------------------------------------------
+# Registers a scheduled task that runs ops/cross_agent_outcome_poller.py every
+# 30 minutes (ssh tunnel -> read-only platform DB -> _l4_cross_agent/memory).
+# Idempotent + has --dry-run; safe to run repeatedly (/F overwrites the task).
+#
+# Run once (as the CURRENT user, NOT SYSTEM — Task Scheduler under SYSTEM has the
+# wrong ~/.ssh path and no ssh-agent):
+#     powershell -ExecutionPolicy Bypass -File ops\setup-l4-poller-task.ps1
+# Unregister:
+#     schtasks /Delete /TN compass-l4-cross-agent-poller /F
+#
+# Prerequisites (see report):
+#   - passwordless ssh key for `Host cloud` (Task Scheduler has no ssh-agent)
+#   - .soul_db_secret present (else the poller safely no-ops and exits 0)
+#   - `py -3` resolves python 3 with psycopg2 installed
+# ---------------------------------------------------------------------------
+
+$ErrorActionPreference = "Stop"
+
+$TaskName  = "compass-l4-cross-agent-poller"
+$PyScript  = Join-Path $PSScriptRoot "cross_agent_outcome_poller.py"
+$LogPath   = Join-Path $env:USERPROFILE ".cache\compass\l4-cross-agent-poller.log"
+$IntervalMinutes = 30
+
+if (-not (Test-Path $PyScript)) {
+    Write-Error "poller script not found next to this file: $PyScript"
+    exit 1
+}
+
+$null = New-Item -ItemType Directory -Path (Split-Path $LogPath) -Force
+
+# /SC MINUTE /MO 30 · runs as the registering (current) user · /F overwrites.
+# Redirect both streams to the log; the poller itself never prints secrets.
+$cmd = "py -3 `"$PyScript`" >> `"$LogPath`" 2>&1"
+& schtasks.exe /Create /TN $TaskName /TR $cmd /SC MINUTE /MO $IntervalMinutes /F | Out-Null
+
+Write-Output "[compass-l4] registered scheduled task"
+Write-Output "  task:   $TaskName"
+Write-Output "  script: $PyScript"
+Write-Output "  every:  $IntervalMinutes min"
+Write-Output "  log:    $LogPath"
+Write-Output ""
+Write-Output "verify:   schtasks /Query /TN $TaskName /V"
+Write-Output "run now:  schtasks /Run /TN $TaskName   (then check the log)"
+Write-Output "remove:   schtasks /Delete /TN $TaskName /F"
+Write-Output ""
+Write-Output "NOTE · reconciler (ops/poi_reconcile_cron.py) is intentionally NOT"
+Write-Output "scheduled here — it has no candidates to settle until L3 candidate"
+Write-Output "firing is activated in the live plugin. Schedule it after activation."

--- a/ops/setup-l4-poller-task.ps1
+++ b/ops/setup-l4-poller-task.ps1
@@ -28,12 +28,39 @@ if (-not (Test-Path $PyScript)) {
     exit 1
 }
 
+# Resolve a python that actually has psycopg2 — `py -3` may pick a different
+# interpreter (e.g. 3.14) WITHOUT psycopg2. Prefer $COMPASS_PYTHON, else the
+# `python` on PATH that imports psycopg2, else fall back to a full path. Task
+# Scheduler has a minimal PATH, so we bake the absolute exe into the task.
+$Python = $env:COMPASS_PYTHON
+if (-not $Python) {
+    foreach ($cand in @((Get-Command python -ErrorAction SilentlyContinue).Source,
+                        "$env:LOCALAPPDATA\Programs\Python\Python313\python.exe",
+                        "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe")) {
+        if ($cand -and (Test-Path $cand)) {
+            & $cand -c "import psycopg2" 2>$null
+            if ($LASTEXITCODE -eq 0) { $Python = $cand; break }
+        }
+    }
+}
+if (-not $Python) {
+    Write-Error "no python with psycopg2 found; set `$env:COMPASS_PYTHON to a python.exe that has psycopg2"
+    exit 1
+}
+Write-Output "[compass-l4] using python: $Python"
+
 $null = New-Item -ItemType Directory -Path (Split-Path $LogPath) -Force
 
 # /SC MINUTE /MO 30 · runs as the registering (current) user · /F overwrites.
-# Redirect both streams to the log; the poller itself never prints secrets.
-$cmd = "py -3 `"$PyScript`" >> `"$LogPath`" 2>&1"
+# schtasks runs /TR directly (no shell), so `>>` redirection must go through
+# `cmd /c`. Inner quotes are doubled for the schtasks arg parser. The poller
+# never prints secrets, so logging both streams is safe.
+$cmd = "cmd /c `"`"`"$Python`"`" `"`"$PyScript`"`" >> `"`"$LogPath`"`" 2>&1`""
 & schtasks.exe /Create /TN $TaskName /TR $cmd /SC MINUTE /MO $IntervalMinutes /F | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "schtasks /Create failed (exit $LASTEXITCODE) · run this in a normal (non-sandboxed) PowerShell, as the current user"
+    exit $LASTEXITCODE
+}
 
 Write-Output "[compass-l4] registered scheduled task"
 Write-Output "  task:   $TaskName"

--- a/proof/local_outcomes.py
+++ b/proof/local_outcomes.py
@@ -1,0 +1,66 @@
+"""Path B · local outcome source · self-closing PoI loop without platform agents.
+
+The platform L4 outcomes (agent_tool_calls) only credit platform agents, but
+~99% of recall traffic is the local user (actor 'unknown'/anon). Path B derives
+a local outcome signal from the user's OWN session_*.md files — their `drift`
+frontmatter is compass's native local quality signal (green = the session stayed
+on-anchor = a positive outcome; yellow/red = drift = negative) — attributed to
+the local actor, so local recalls settle into cumulative_impact and the user
+sees recursive self-improvement from their own usage alone.
+
+NO LLM · pure filename + frontmatter parse. Feeds proof.poi_reconciler.reconcile.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional
+
+from .l1_grouper_compat import parse_session_frontmatter_safe
+
+_FN_RE = re.compile(r"session_(\d{8})(?:[-_](\d{4}))?")
+
+
+def ts_from_filename(name: str) -> Optional[str]:
+    """session_YYYYMMDD[-HHMM]_... -> ISO8601 string · None if not a session file."""
+    m = _FN_RE.match(name)
+    if not m:
+        return None
+    ymd, hm = m.group(1), m.group(2)
+    y, mo, d = ymd[0:4], ymd[4:6], ymd[6:8]
+    if hm:
+        return f"{y}-{mo}-{d}T{hm[0:2]}:{hm[2:4]}:00+00:00"
+    return f"{y}-{mo}-{d}T00:00:00+00:00"
+
+
+def _drift_to_success(drift: str) -> Optional[bool]:
+    d = (drift or "").strip().lower()
+    if d == "green":
+        return True
+    if d in ("yellow", "red"):
+        return False
+    return None  # no usable signal
+
+
+def local_outcomes(memory_dir, actor: str, since_iso: Optional[str] = None) -> list:
+    """Scan the user's session_*.md files → outcome dicts for ``actor``.
+
+    Returns [{agent_id, success, ts}] for each session with a usable drift
+    signal. ``since_iso`` filters by the session's filename timestamp.
+    """
+    mem = Path(memory_dir)
+    if not mem.exists():
+        return []
+    out = []
+    for p in sorted(mem.glob("session_*.md")):
+        ts = ts_from_filename(p.name)
+        if ts is None:
+            continue
+        if since_iso and ts < since_iso:
+            continue
+        front = parse_session_frontmatter_safe(p)
+        success = _drift_to_success(front.get("drift", ""))
+        if success is None:
+            continue
+        out.append({"agent_id": actor, "success": success, "ts": ts})
+    return out

--- a/proof/poi_reconciler.py
+++ b/proof/poi_reconciler.py
@@ -1,0 +1,159 @@
+"""PoI reconciler · closes the L3 loop (candidate × outcome → settled PoI).
+
+Recall emits *candidates* (`poi_candidates.jsonl`): "memory M was surfaced to
+actor A at time T" — no outcome yet. The L4 poller brings real agent *outcomes*
+(agent_tool_calls / engine_cycle_outcomes: agent_id + success + ts). This module
+joins them: for each unsettled candidate, find the earliest outcome by the SAME
+actor within a window, map it to success/failure, and settle a full PoI event
+(emit_full) that credits cumulative_impact on the cited memory.
+
+Join namespace: candidate.actor = recall's _resolve_default_actor()
+(COMPASS_AGENT_ID > CLAUDE_AGENT_ID > anon-hash). Platform agents that set
+COMPASS_AGENT_ID to their platform agent_id will match agent_tool_calls.agent_id;
+the user's local anon actor matches nothing and simply never settles (correct).
+
+NO LLM. Pure join + the existing deterministic poi_calculator/emit_full.
+Reference: paper/SPEC_PROOF_OF_IMPACT.md.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from .poi_schema import ProofOfImpact
+from .poi_calculator import compute_with_drift
+from .poi_emitter import emit_full
+
+CANDIDATE_SIDECAR = "poi_candidates.jsonl"
+SETTLED_STATE = "poi_settled.json"
+DEFAULT_WINDOW_S = 86400  # match an outcome within 24h of the recall
+
+
+def outcome_to_action_outcome(outcome: dict) -> str:
+    """Map an L4 outcome's success flag to a ProofOfImpact action_outcome."""
+    s = outcome.get("success")
+    if s is True:
+        return "success"
+    if s is False:
+        return "failure"
+    return "pending"
+
+
+def _parse_ts(ts) -> Optional[datetime]:
+    if isinstance(ts, datetime):
+        return ts
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def candidate_key(cand: dict) -> str:
+    """Stable idempotency key for one candidate line."""
+    raw = "|".join(str(cand.get(k, "")) for k in ("ts", "actor", "memory", "query_hash"))
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:20]
+
+
+def match_outcome(cand: dict, outcomes: list, window_seconds: int = DEFAULT_WINDOW_S) -> Optional[dict]:
+    """Earliest outcome by the same actor strictly after the candidate, in window."""
+    c_ts = _parse_ts(cand.get("ts"))
+    actor = cand.get("actor")
+    if c_ts is None or not actor:
+        return None
+    best = None
+    best_ts = None
+    for o in outcomes:
+        if o.get("agent_id") != actor:
+            continue
+        o_ts = _parse_ts(o.get("ts"))
+        if o_ts is None or o_ts <= c_ts:
+            continue
+        if (o_ts - c_ts).total_seconds() > window_seconds:
+            continue
+        if best_ts is None or o_ts < best_ts:
+            best, best_ts = o, o_ts
+    return best
+
+
+def load_candidates(path) -> list:
+    p = Path(path)
+    if not p.exists():
+        return []
+    out = []
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            d = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if d.get("kind") == "candidate":
+            out.append(d)
+    return out
+
+
+def load_settled(path) -> set:
+    p = Path(path)
+    if not p.exists():
+        return set()
+    try:
+        return set(json.loads(p.read_text(encoding="utf-8")).get("keys", []))
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+
+def save_settled(path, keys: set) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    # keep last 5000 keys to bound growth
+    p.write_text(json.dumps({"keys": sorted(keys)[-5000:]}, indent=0), encoding="utf-8")
+
+
+def reconcile(candidates: list, outcomes: list, *, settled_keys: Optional[set] = None,
+              window_seconds: int = DEFAULT_WINDOW_S, memory_root=None,
+              cache_dir=None) -> dict:
+    """Settle each unsettled candidate that has a matching outcome.
+
+    Mutates ``settled_keys`` in place (so a second call is idempotent). Calls
+    emit_full for each match → updates cumulative_impact on the cited memory.
+    """
+    if settled_keys is None:
+        settled_keys = set()
+    settled = skipped_no_match = skipped_already = 0
+
+    for cand in candidates:
+        key = candidate_key(cand)
+        if key in settled_keys:
+            skipped_already += 1
+            continue
+        outcome = match_outcome(cand, outcomes, window_seconds=window_seconds)
+        if outcome is None:
+            skipped_no_match += 1
+            continue
+        memory = cand.get("memory")
+        if not memory:
+            skipped_no_match += 1
+            continue
+        poi = ProofOfImpact(
+            action_id=f"recon-{key}",
+            agent_id=cand["actor"],
+            cited_memory_paths=[memory],
+            action_outcome=outcome_to_action_outcome(outcome),
+            timestamp_action=str(cand.get("ts", "")),
+            timestamp_outcome=str(outcome.get("ts", "")),
+            notes=f"reconciled from L4 outcome of {cand['actor']}",
+        )
+        root = Path(memory_root) if memory_root else None
+        compute_with_drift(poi, memory_root=root)
+        emit_full(poi, cache_dir=Path(cache_dir) if cache_dir else None, memory_root=root)
+        settled_keys.add(key)
+        settled += 1
+
+    return {"settled": settled, "skipped_no_match": skipped_no_match,
+            "skipped_already": skipped_already}

--- a/proof/poi_reconciler.py
+++ b/proof/poi_reconciler.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -44,18 +44,26 @@ def outcome_to_action_outcome(outcome: dict) -> str:
 
 def _parse_ts(ts) -> Optional[datetime]:
     if isinstance(ts, datetime):
-        return ts
-    if not ts:
+        dt = ts
+    elif not ts:
         return None
-    try:
-        return datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
-    except ValueError:
-        return None
+    else:
+        try:
+            dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    # H1 · normalize naive timestamps to UTC so candidate (always aware) and
+    # platform outcomes (may be naive) compare without TypeError.
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def candidate_key(cand: dict) -> str:
-    """Stable idempotency key for one candidate line."""
-    raw = "|".join(str(cand.get(k, "")) for k in ("ts", "actor", "memory", "query_hash"))
+    """Stable idempotency key · (actor, memory, query) WITHOUT second-level ts,
+    so the same memory recalled for the same query in different seconds shares a
+    key and a single outcome cannot double-credit it (M2)."""
+    raw = "|".join(str(cand.get(k, "")) for k in ("actor", "memory", "query_hash"))
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:20]
 
 
@@ -140,6 +148,14 @@ def reconcile(candidates: list, outcomes: list, *, settled_keys: Optional[set] =
         if not memory:
             skipped_no_match += 1
             continue
+        # M1 · only settle if the cited memory file actually exists · otherwise
+        # emit_full would update no frontmatter = a fake closed loop. Skip
+        # WITHOUT burning the key (retryable once the file shows up).
+        root = Path(memory_root) if memory_root else None
+        mem_path = root / memory if (root and not Path(memory).is_absolute()) else Path(memory)
+        if not mem_path.exists():
+            skipped_no_match += 1
+            continue
         poi = ProofOfImpact(
             action_id=f"recon-{key}",
             agent_id=cand["actor"],
@@ -149,7 +165,6 @@ def reconcile(candidates: list, outcomes: list, *, settled_keys: Optional[set] =
             timestamp_outcome=str(outcome.get("ts", "")),
             notes=f"reconciled from L4 outcome of {cand['actor']}",
         )
-        root = Path(memory_root) if memory_root else None
         compute_with_drift(poi, memory_root=root)
         emit_full(poi, cache_dir=Path(cache_dir) if cache_dir else None, memory_root=root)
         settled_keys.add(key)

--- a/recall.py
+++ b/recall.py
@@ -1251,6 +1251,20 @@ def try_daemon_recall(mem_dir: Path, user_prompt: str) -> bool:
                 print(_notice)
         except Exception:
             pass
+
+        # L3 PoI candidate emission · ALSO fire on the daemon recall path. The
+        # inline path (render_v02_vector_mode) already emits, but production
+        # recall goes through the daemon, so without this candidates never land
+        # → poi_candidates.jsonl stays empty → L3 has 0 events to reconcile.
+        # Adapts the daemon recall dict-list to the (score, entry) shape.
+        # Guarded by COMPASS_NO_POI_CANDIDATE=1. Never breaks recall.
+        try:
+            if recall and os.environ.get("COMPASS_NO_POI_CANDIDATE") != "1":
+                from proof.poi_emitter import emit_poi_candidate
+                _top = [(r.get("score", 0.0), r) for r in recall]
+                emit_poi_candidate(_top, query=user_prompt, agent_id=_resolve_default_actor())
+        except Exception as _e:
+            sys.stderr.write(f"[PoI candidate · daemon] skipped: {_e!r}\n")
         return True
     except Exception as e:
         sys.stderr.write(f"[nautilus-compass daemon] unreachable ({e}) · fallback inline\n")

--- a/recall.py
+++ b/recall.py
@@ -1249,8 +1249,8 @@ def try_daemon_recall(mem_dir: Path, user_prompt: str) -> bool:
             if _notice:
                 print()
                 print(_notice)
-        except Exception:
-            pass
+        except Exception as _e:
+            sys.stderr.write(f"[L2 metamemory] skipped: {_e!r}\n")
 
         # L3 PoI candidate emission · ALSO fire on the daemon recall path. The
         # inline path (render_v02_vector_mode) already emits, but production

--- a/recall.py
+++ b/recall.py
@@ -1237,6 +1237,20 @@ def try_daemon_recall(mem_dir: Path, user_prompt: str) -> bool:
                 print(f"🟢 + 24h 内其他 memory ({len(fresh_extra)} · 当前心智 · 即便低 cosine 也注意):")
                 for e in fresh_extra:
                     print(f"  · [{e['age_str']:>5} old] {e['path']} — {e['description'][:80]}")
+
+        # L2 metamemory · 自知层:fires on empty OR weak recall · the
+        # hallucinate-absence cure — tells the subject LLM when compass has no
+        # reliable evidence so it does not fabricate a "prior finding".
+        # Deterministic by default (no LLM · black-box moat). Never breaks recall.
+        try:
+            from metamemory import build_recall_result, format_metamemory_notice
+            _rr = build_recall_result(user_prompt, recall or [])
+            _notice = format_metamemory_notice(_rr)
+            if _notice:
+                print()
+                print(_notice)
+        except Exception:
+            pass
         return True
     except Exception as e:
         sys.stderr.write(f"[nautilus-compass daemon] unreachable ({e}) · fallback inline\n")

--- a/tests/metamemory/test_builder.py
+++ b/tests/metamemory/test_builder.py
@@ -1,0 +1,119 @@
+"""Tests for metamemory.builder.build_recall_result · the L2 integration glue.
+
+Maps real recall match dicts -> RecallResult (confidence per match + source_trail
++ gaps), with a pluggable LLM backend hook (default None = deterministic, no LLM,
+black-box moat preserved).
+"""
+from __future__ import annotations
+
+from metamemory.builder import build_recall_result, format_metamemory_notice
+from metamemory.result import RecallResult
+
+
+def _match(path, score, age_seconds=0, type_="reference", concept="x", description="d"):
+    return {"path": path, "score": score, "age_seconds": age_seconds,
+            "type": type_, "concept": concept, "name": path, "description": description}
+
+
+def test_returns_recall_result_with_per_match_confidence():
+    matches = [_match("a.md", 0.9), _match("b.md", 0.7)]
+    rr = build_recall_result("what is X", matches)
+    assert isinstance(rr, RecallResult)
+    assert len(rr.matches) == 2
+    assert len(rr.confidence) == 2
+    assert {cv.match_id for cv in rr.confidence} == {"a.md", "b.md"}
+
+
+def test_source_trail_maps_each_match_to_origin():
+    matches = [_match("session_20260602_foo.md", 0.8, type_="feedback")]
+    rr = build_recall_result("q", matches)
+    assert "session_20260602_foo.md" in rr.source_trail
+    # origin string carries something identifying (the file / type)
+    assert "feedback" in rr.source_trail["session_20260602_foo.md"]
+
+
+def test_empty_matches_surfaces_gap():
+    # the hallucinate-absence cure: no recall -> explicit "no evidence" gap
+    rr = build_recall_result("obscure thing", [])
+    assert rr.is_empty()
+    assert len(rr.gaps) == 1
+    assert rr.gaps[0].topic == "obscure thing"
+
+
+def test_weak_matches_surface_gap():
+    # all low score + old -> low composite -> gap
+    matches = [_match("a.md", 0.1, age_seconds=365 * 86400)]
+    rr = build_recall_result("q", matches, gap_threshold=0.4)
+    assert len(rr.gaps) == 1
+
+
+def test_strong_match_no_gap():
+    matches = [_match("a.md", 0.95, age_seconds=0)]
+    rr = build_recall_result("q", matches, gap_threshold=0.4)
+    assert rr.gaps == []
+
+
+def test_recent_match_has_higher_recency_than_old():
+    fresh = build_recall_result("q", [_match("a.md", 0.8, age_seconds=0)])
+    stale = build_recall_result("q", [_match("a.md", 0.8, age_seconds=60 * 86400)])
+    assert fresh.confidence[0].recency_factor > stale.confidence[0].recency_factor
+
+
+def test_score_clamped_to_unit_interval():
+    # recall scores can exceed 1 (reranker) or go negative; ConfidenceVector wants [0,1]
+    rr = build_recall_result("q", [_match("a.md", 1.7), _match("b.md", -0.3)])
+    for cv in rr.confidence:
+        assert 0.0 <= cv.score <= 1.0
+
+
+def test_llm_backend_none_is_deterministic():
+    matches = [_match("a.md", 0.95)]
+    rr1 = build_recall_result("q", matches, llm_backend=None)
+    rr2 = build_recall_result("q", matches, llm_backend=None)
+    assert [g.topic for g in rr1.gaps] == [g.topic for g in rr2.gaps]
+
+
+def test_llm_backend_can_refine_gaps():
+    from metamemory.gap import GapStatement
+
+    called = {}
+
+    def fake_backend(query, matches, det_gaps):
+        called["yes"] = True
+        return [GapStatement(topic="llm-found-gap", reason="semantic")]
+
+    rr = build_recall_result("q", [_match("a.md", 0.95)], llm_backend=fake_backend)
+    assert called.get("yes") is True
+    assert any(g.topic == "llm-found-gap" for g in rr.gaps)
+
+
+def test_llm_backend_failure_falls_back_to_deterministic():
+    # a flaky LLM backend must never break recall · degrade to deterministic gaps
+    def boom(query, matches, det_gaps):
+        raise RuntimeError("backend down")
+
+    rr = build_recall_result("obscure", [], llm_backend=boom)
+    # deterministic gap (empty matches) survives the backend failure
+    assert len(rr.gaps) == 1
+    assert rr.gaps[0].topic == "obscure"
+
+
+# ----------------------------------------------------- format_metamemory_notice
+def test_format_notice_empty_when_strong_evidence():
+    rr = build_recall_result("q", [_match("a.md", 0.95, age_seconds=0)])
+    # strong evidence, no gap -> no noise injected into the agent's context
+    assert format_metamemory_notice(rr) == ""
+
+
+def test_format_notice_warns_on_gap():
+    rr = build_recall_result("the X thing", [])
+    notice = format_metamemory_notice(rr)
+    assert notice != ""
+    # must mention the topic and convey absence of evidence
+    assert "the X thing" in notice
+    assert "没有" in notice and "evidence" in notice.lower()
+
+
+def test_format_notice_is_string():
+    rr = build_recall_result("q", [_match("a.md", 0.1, age_seconds=999 * 86400)])
+    assert isinstance(format_metamemory_notice(rr), str)

--- a/tests/test_cross_agent_poller.py
+++ b/tests/test_cross_agent_poller.py
@@ -1,0 +1,198 @@
+"""Tests for ops/cross_agent_outcome_poller.py · L4 cross-agent outcome poller.
+
+Covers pure transforms (DB row -> compass session_*.md) + watermark state +
+drift-signal aggregation. DB I/O (ssh tunnel + psycopg2) is integration-verified
+separately and kept thin / not unit-tested here.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import importlib.util
+import sys
+
+_OPS = Path(__file__).resolve().parent.parent / "ops" / "cross_agent_outcome_poller.py"
+_spec = importlib.util.spec_from_file_location("cross_agent_outcome_poller", _OPS)
+poller = importlib.util.module_from_spec(_spec)
+sys.modules["cross_agent_outcome_poller"] = poller
+_spec.loader.exec_module(poller)
+
+
+# ---------------------------------------------------------------- parse_secret
+def test_parse_secret_key_value_lines(tmp_path: Path):
+    f = tmp_path / ".secret"
+    f.write_text(
+        "compass_sub read-only credential (do not commit)\n"
+        "password: s3cr3t-with:colon\n"
+        "host: localhost\n"
+        "port: 5432\n"
+        "dbname: nautilus_production\n"
+        "schema: public\n",
+        encoding="utf-8",
+    )
+    cfg = poller.parse_secret(str(f))
+    assert cfg["password"] == "s3cr3t-with:colon"  # value may itself contain colon
+    assert cfg["host"] == "localhost"
+    assert cfg["port"] == "5432"
+    assert cfg["dbname"] == "nautilus_production"
+    # the comment header line (no key:value) is ignored
+    assert "compass_sub" not in cfg
+
+
+def test_parse_secret_missing_password_raises(tmp_path: Path):
+    f = tmp_path / ".secret"
+    f.write_text("host: localhost\nport: 5432\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        poller.parse_secret(str(f))
+
+
+# ------------------------------------------------------ build_b2_session_md
+def _b2_row(**over):
+    row = {
+        "id": 125824,
+        "agent_id": "v5-singleton",
+        "tool_name": "write_file",
+        "args_summary": "path=foo.py",
+        "output_summary": "wrote 12 lines",
+        "success": True,
+        "elapsed_ms": 340,
+        "ts": datetime(2026, 6, 2, 14, 30, tzinfo=timezone.utc),
+        "phase": "ship",
+    }
+    row.update(over)
+    return row
+
+
+def test_build_b2_filename_deterministic_from_id_and_ts():
+    fn1, _ = poller.build_b2_session_md(_b2_row())
+    fn2, _ = poller.build_b2_session_md(_b2_row())
+    assert fn1 == fn2  # idempotent · same row -> same filename (no now())
+    assert fn1.startswith("session_")
+    assert fn1.endswith(".md")
+    assert "125824" in fn1  # stable id present -> watermark-safe dedup
+
+
+def test_build_b2_success_is_green_failure_is_yellow():
+    _, ok = poller.build_b2_session_md(_b2_row(success=True))
+    _, bad = poller.build_b2_session_md(_b2_row(success=False))
+    assert "drift: green" in ok
+    assert "drift: yellow" in bad
+
+
+def test_build_b2_frontmatter_has_recall_fields():
+    _, md = poller.build_b2_session_md(_b2_row())
+    assert md.startswith("---")
+    for field in ("type: cross-agent-tool-call", "agent_type: v5-singleton",
+                  "thread_id:", "tool_name: write_file"):
+        assert field in md, f"missing {field!r}"
+    # body retains the source summary for recall
+    assert "wrote 12 lines" in md
+
+
+def test_build_b2_handles_non_ascii_and_none_summary():
+    # output_summary None and non-ascii agent must not crash; filename ascii-safe
+    fn, md = poller.build_b2_session_md(
+        _b2_row(agent_id="才燊-agent", output_summary=None, args_summary=None)
+    )
+    assert fn.isascii()
+    assert "---" in md
+
+
+# ------------------------------------------------------ build_a2_session_md
+def _a2_row(**over):
+    row = {
+        "cycle_id": "cyc_20260602_001",
+        "spec": "add poller",
+        "ship_status": "shipped",
+        "semantic_pass": True,
+        "tests_pass": True,
+        "actual_lines_added": 120,
+        "actual_lines_removed": 4,
+        "drift_ratio": 0.02,
+        "composite_score": 0.91,
+        "git_sha": "abc1234",
+        "created_at": datetime(2026, 6, 2, 9, 0, tzinfo=timezone.utc),
+        "goal_source": "self-audit",
+        "fitness_delta": 0.05,
+    }
+    row.update(over)
+    return row
+
+
+def test_build_a2_filename_deterministic_from_cycle_id():
+    fn1, _ = poller.build_a2_session_md(_a2_row())
+    fn2, _ = poller.build_a2_session_md(_a2_row())
+    assert fn1 == fn2
+    assert "cyc_20260602_001" in fn1
+    assert fn1.endswith(".md")
+
+
+def test_build_a2_failed_tests_is_drift_signal():
+    _, ok = poller.build_a2_session_md(_a2_row(semantic_pass=True, tests_pass=True))
+    _, bad = poller.build_a2_session_md(_a2_row(tests_pass=False))
+    assert "drift: green" in ok
+    assert "drift: yellow" in bad
+
+
+def test_build_a2_success_with_null_checks_is_green():
+    # real data: semantic_pass / tests_pass are NULL; ship_status carries health.
+    # ship_status='success' with null checks must NOT be a false drift (cry-wolf).
+    _, ok = poller.build_a2_session_md(
+        _a2_row(ship_status="success", semantic_pass=None, tests_pass=None))
+    assert "drift: green" in ok
+    _, bad = poller.build_a2_session_md(
+        _a2_row(ship_status="fail", semantic_pass=None, tests_pass=None))
+    assert "drift: yellow" in bad
+
+
+def test_build_a2_frontmatter_has_fields():
+    _, md = poller.build_a2_session_md(_a2_row())
+    assert "type: cross-agent-cycle-outcome" in md
+    assert "ship_status: shipped" in md
+    assert "composite_score" in md
+
+
+# ------------------------------------------------------ compute_drift_signal
+def test_drift_signal_all_success_no_alert():
+    rows = [_b2_row(id=i, success=True) for i in range(10)]
+    sig = poller.compute_drift_signal("v5-singleton", rows)
+    assert sig["agent_id"] == "v5-singleton"
+    assert sig["n"] == 10
+    assert sig["success_rate"] == 1.0
+    assert sig["alert"] is False
+
+
+def test_drift_signal_low_success_rate_alerts():
+    rows = ([_b2_row(id=i, success=False) for i in range(6)]
+            + [_b2_row(id=100 + i, success=True) for i in range(4)])
+    sig = poller.compute_drift_signal("v5-singleton", rows)
+    assert sig["n"] == 10
+    assert sig["success_rate"] == pytest.approx(0.4)
+    assert sig["alert"] is True  # 40% < 0.5 threshold
+
+
+def test_drift_signal_too_few_samples_no_alert():
+    # below min-sample floor -> never alert (avoid cry-wolf on n=1)
+    rows = [_b2_row(id=1, success=False)]
+    sig = poller.compute_drift_signal("v5-singleton", rows)
+    assert sig["alert"] is False
+    assert sig["n"] == 1
+
+
+# ------------------------------------------------------ watermark state
+def test_watermark_roundtrip(tmp_path: Path):
+    p = tmp_path / "wm.json"
+    poller.save_watermark(str(p), {"last_b2_id": 999, "last_a2_ts": "2026-06-02T09:00:00+00:00"})
+    wm = poller.load_watermark(str(p))
+    assert wm["last_b2_id"] == 999
+    assert wm["last_a2_ts"] == "2026-06-02T09:00:00+00:00"
+
+
+def test_watermark_missing_file_returns_defaults(tmp_path: Path):
+    wm = poller.load_watermark(str(tmp_path / "nope.json"))
+    assert wm["last_b2_id"] == 0
+    assert wm["last_a2_ts"] is None

--- a/tests/test_cross_agent_poller.py
+++ b/tests/test_cross_agent_poller.py
@@ -183,6 +183,36 @@ def test_drift_signal_too_few_samples_no_alert():
     assert sig["n"] == 1
 
 
+# -------------------------------------------------- b2 rollup (anti-flooding)
+def test_b2_rollup_single_file_for_many_agents():
+    # b2 is 125k rows · MUST NOT write per-row files · one rollup summarises all
+    signals = [
+        {"agent_id": "v5", "n": 100, "successes": 95, "success_rate": 0.95, "alert": False},
+        {"agent_id": "kairos", "n": 20, "successes": 6, "success_rate": 0.30, "alert": True},
+    ]
+    fn, md = poller.build_b2_rollup_session_md(signals, window_label="24h")
+    assert fn.startswith("session_") and fn.endswith(".md")
+    assert "xrollup" in fn  # distinct from per-call xacall files
+    assert "v5" in md and "kairos" in md
+    assert "type: cross-agent-drift-rollup" in md
+
+
+def test_b2_rollup_drift_yellow_when_any_alert():
+    sig_ok = [{"agent_id": "v5", "n": 100, "successes": 99, "success_rate": 0.99, "alert": False}]
+    sig_bad = [{"agent_id": "k", "n": 20, "successes": 5, "success_rate": 0.25, "alert": True}]
+    _, ok = poller.build_b2_rollup_session_md(sig_ok, window_label="24h")
+    _, bad = poller.build_b2_rollup_session_md(sig_bad, window_label="24h")
+    assert "drift: green" in ok
+    assert "drift: yellow" in bad
+
+
+def test_b2_rollup_empty_signals_is_stall_marker():
+    # no rows in window -> still emit a marker (daemon-stall / silence is signal)
+    fn, md = poller.build_b2_rollup_session_md([], window_label="24h")
+    assert fn.endswith(".md")
+    assert "no agent tool activity" in md.lower() or "0 agent" in md.lower()
+
+
 # ------------------------------------------------------ watermark state
 def test_watermark_roundtrip(tmp_path: Path):
     p = tmp_path / "wm.json"

--- a/tests/test_local_outcomes.py
+++ b/tests/test_local_outcomes.py
@@ -1,0 +1,91 @@
+"""Tests for proof.local_outcomes · Path B (local self-closing loop).
+
+The platform L4 outcomes only credit platform agents. Most recall traffic is the
+local user (actor 'unknown'/anon), whose actions have no platform outcome. Path B
+derives a LOCAL outcome signal from the user's own session_*.md files (their
+`drift` frontmatter: green = success, yellow/red = not), attributed to the local
+actor, so local recalls can settle into cumulative_impact without any platform
+agent. NO LLM · pure frontmatter + filename parse.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from proof import local_outcomes as LO
+
+
+def _session(tmp: Path, name: str, drift: str = "green") -> Path:
+    p = tmp / name
+    p.write_text(f"---\nname: x\ntype: session\ndrift: {drift}\n---\n\nbody\n",
+                 encoding="utf-8")
+    return p
+
+
+def test_parse_ts_from_session_filename():
+    # session_YYYYMMDD-HHMM_... -> iso ts
+    ts = LO.ts_from_filename("session_20260602-1430_foo.md")
+    assert ts is not None and ts.startswith("2026-06-02T14:30")
+
+
+def test_parse_ts_underscore_variant():
+    ts = LO.ts_from_filename("session_20260602_foo.md")
+    assert ts is not None and ts.startswith("2026-06-02")
+
+
+def test_parse_ts_returns_none_for_non_session():
+    assert LO.ts_from_filename("reference_thing.md") is None
+
+
+def test_green_session_is_success(tmp_path: Path):
+    _session(tmp_path, "session_20260602-1000_a.md", drift="green")
+    outs = LO.local_outcomes(tmp_path, actor="unknown")
+    assert len(outs) == 1
+    assert outs[0]["agent_id"] == "unknown"
+    assert outs[0]["success"] is True
+
+
+def test_yellow_and_red_sessions_are_failure(tmp_path: Path):
+    _session(tmp_path, "session_20260602-1000_y.md", drift="yellow")
+    _session(tmp_path, "session_20260602-1100_r.md", drift="red")
+    outs = LO.local_outcomes(tmp_path, actor="unknown")
+    assert all(o["success"] is False for o in outs)
+    assert len(outs) == 2
+
+
+def test_non_session_files_skipped(tmp_path: Path):
+    _session(tmp_path, "session_20260602-1000_a.md", drift="green")
+    (tmp_path / "reference_x.md").write_text("---\ndrift: green\n---\nbody\n", encoding="utf-8")
+    outs = LO.local_outcomes(tmp_path, actor="unknown")
+    assert len(outs) == 1  # only the session_ file
+
+
+def test_since_filter(tmp_path: Path):
+    _session(tmp_path, "session_20260601-1000_old.md", drift="green")
+    _session(tmp_path, "session_20260603-1000_new.md", drift="green")
+    outs = LO.local_outcomes(tmp_path, actor="unknown", since_iso="2026-06-02T00:00:00")
+    assert len(outs) == 1
+    assert outs[0]["ts"].startswith("2026-06-03")
+
+
+def test_missing_drift_defaults_skipped_or_pending(tmp_path: Path):
+    p = tmp_path / "session_20260602-1000_nodrift.md"
+    p.write_text("---\nname: x\ntype: session\n---\nbody\n", encoding="utf-8")
+    outs = LO.local_outcomes(tmp_path, actor="unknown")
+    # no drift field -> no usable outcome signal -> skipped
+    assert outs == []
+
+
+def test_reconcile_with_local_outcomes_settles(tmp_path: Path):
+    # end-to-end: a local candidate + a later green local session -> settles
+    from proof import poi_reconciler as R
+    mem = tmp_path / "session_20260602-0900_cited.md"
+    mem.write_text("---\nname: cited\ntype: reference\ndrift: green\nagent_type: other\n---\nbody\n",
+                   encoding="utf-8")
+    _session(tmp_path, "session_20260602-1000_outcome.md", drift="green")
+    cand = {"ts": "2026-06-02T09:30:00+00:00", "actor": "unknown",
+            "memory": "session_20260602-0900_cited.md", "query_hash": "h", "rank": 0, "score": 0.8}
+    outs = LO.local_outcomes(tmp_path, actor="unknown")
+    res = R.reconcile([cand], outs, settled_keys=set(), window_seconds=86400,
+                      memory_root=tmp_path, cache_dir=tmp_path)
+    assert res["settled"] == 1
+    assert "cumulative_impact:" in mem.read_text(encoding="utf-8")

--- a/tests/test_poi_daemon_candidate.py
+++ b/tests/test_poi_daemon_candidate.py
@@ -1,0 +1,38 @@
+"""Lock the contract the daemon-path candidate adapter relies on.
+
+try_daemon_recall adapts its recall dict-list to `[(score, entry), ...]` where
+entry carries only `path` (a filename, daemon shape — no `fullpath`). This test
+verifies emit_poi_candidate accepts that shape and writes candidate lines, so
+the L3 candidate stream actually lands on the production (daemon) path.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from proof.poi_emitter import emit_poi_candidate
+
+
+def test_daemon_shape_entries_produce_candidates(tmp_path: Path):
+    # daemon recall list: dicts with filename-only 'path' (no fullpath)
+    recall = [
+        {"score": 0.81, "path": "session_a.md", "age_seconds": 100},
+        {"score": 0.77, "path": "session_b.md", "age_seconds": 8000},
+    ]
+    top = [(r.get("score", 0.0), r) for r in recall]
+    n = emit_poi_candidate(top, query="some query", agent_id="kairos", cache_dir=tmp_path)
+    assert n == 2
+    lines = (tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    rec = json.loads(lines[0])
+    assert rec["kind"] == "candidate"
+    assert rec["actor"] == "kairos"
+    assert rec["memory"] in {"session_a.md", "session_b.md"}
+    assert "query_hash" in rec and "score" in rec
+
+
+def test_empty_recall_writes_nothing(tmp_path: Path):
+    n = emit_poi_candidate([], query="q", agent_id="kairos", cache_dir=tmp_path)
+    assert n == 0
+    assert not (tmp_path / "poi_candidates.jsonl").exists() or \
+        (tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip() == ""

--- a/tests/test_poi_reconciler.py
+++ b/tests/test_poi_reconciler.py
@@ -127,6 +127,57 @@ def test_reconcile_no_match_does_not_settle(tmp_path):
     assert res["skipped_no_match"] == 1
 
 
+def test_match_handles_naive_outcome_ts_without_crashing():
+    # H1: a platform outcome may carry a naive ts (no tz). Must not raise
+    # "can't compare offset-naive and offset-aware".
+    cand = _cand(ts="2026-06-02T10:00:00+00:00")
+    outcomes = [{"agent_id": "kairos", "success": True,
+                 "ts": "2026-06-02T10:05:00"}]  # naive, no +00:00
+    m = R.match_outcome(cand, outcomes, window_seconds=86400)
+    assert m is not None  # treated as UTC, matches in-window
+
+
+def test_reconcile_with_naive_outcome_does_not_crash(tmp_path):
+    _write_memory(tmp_path, name="m.md")
+    cands = [_cand(memory="m.md", actor="kairos", ts="2026-06-02T10:00:00+00:00")]
+    outs = [{"agent_id": "kairos", "success": True, "ts": "2026-06-02T10:05:00"}]
+    res = R.reconcile(cands, outs, settled_keys=set(), window_seconds=86400,
+                      memory_root=tmp_path, cache_dir=tmp_path)
+    assert res["settled"] == 1
+
+
+def test_reconcile_missing_memory_file_not_settled(tmp_path):
+    # M1: if the cited memory file doesn't exist, emit_full updates nothing →
+    # must NOT count as settled (no fake closed loop) and stay retryable.
+    cands = [_cand(memory="does_not_exist.md", actor="kairos")]
+    outs = [_out(agent_id="kairos", success=True)]
+    seen = set()
+    res = R.reconcile(cands, outs, settled_keys=seen, window_seconds=86400,
+                      memory_root=tmp_path, cache_dir=tmp_path)
+    assert res["settled"] == 0
+    assert len(seen) == 0  # key not burned → retryable later
+
+
+def test_candidate_key_ignores_second_level_ts(tmp_path):
+    # M2: same (actor, memory, query) recalled in different seconds must share a
+    # key so one outcome can't double-credit the memory.
+    a = R.candidate_key(_cand(ts="2026-06-02T10:00:00+00:00", memory="m.md"))
+    b = R.candidate_key(_cand(ts="2026-06-02T10:00:05+00:00", memory="m.md"))
+    assert a == b
+
+
+def test_reconcile_no_double_count_across_seconds(tmp_path):
+    mem = _write_memory(tmp_path, name="m.md")
+    cands = [
+        _cand(memory="m.md", actor="kairos", ts="2026-06-02T10:00:00+00:00"),
+        _cand(memory="m.md", actor="kairos", ts="2026-06-02T10:00:05+00:00"),
+    ]
+    outs = [_out(agent_id="kairos", success=True, ts="2026-06-02T10:30:00+00:00")]
+    res = R.reconcile(cands, outs, settled_keys=set(), window_seconds=86400,
+                      memory_root=tmp_path, cache_dir=tmp_path)
+    assert res["settled"] == 1  # not 2
+
+
 def test_reconcile_failure_outcome_gives_negative_impact(tmp_path):
     mem = _write_memory(tmp_path, name="m.md")
     cands = [_cand(memory="m.md", actor="kairos")]

--- a/tests/test_poi_reconciler.py
+++ b/tests/test_poi_reconciler.py
@@ -1,0 +1,140 @@
+"""Tests for proof.poi_reconciler · closes the L3 loop.
+
+Joins recall-time PoI candidates (memory surfaced to actor · no outcome) with
+real agent outcomes (from L4 cross-agent data) → settles each match into a full
+PoI event (emit_full) that credits cumulative_impact on the cited memory.
+
+Pure matching/mapping is unit-tested here; emit_full integration is exercised
+against a temp memory file (verifies cumulative_impact actually lands).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from proof import poi_reconciler as R
+
+
+# -------------------------------------------------- outcome -> action_outcome
+def test_outcome_success_maps_to_success():
+    assert R.outcome_to_action_outcome({"success": True}) == "success"
+    assert R.outcome_to_action_outcome({"success": False}) == "failure"
+
+
+def test_outcome_none_is_pending():
+    assert R.outcome_to_action_outcome({"success": None}) == "pending"
+
+
+# ------------------------------------------------------------ match_outcome
+def _cand(ts="2026-06-02T10:00:00+00:00", actor="kairos", memory="m.md", qh="abc"):
+    return {"ts": ts, "actor": actor, "memory": memory, "query_hash": qh,
+            "rank": 0, "score": 0.8}
+
+
+def _out(agent_id="kairos", success=True, ts="2026-06-02T10:05:00+00:00"):
+    return {"agent_id": agent_id, "success": success, "ts": ts}
+
+
+def test_match_picks_outcome_for_same_actor_after_candidate():
+    cand = _cand()
+    outcomes = [_out(ts="2026-06-02T10:05:00+00:00")]
+    m = R.match_outcome(cand, outcomes, window_seconds=86400)
+    assert m is not None
+    assert m["agent_id"] == "kairos"
+
+
+def test_match_rejects_different_actor():
+    cand = _cand(actor="kairos")
+    outcomes = [_out(agent_id="v7-telegram")]
+    assert R.match_outcome(cand, outcomes, window_seconds=86400) is None
+
+
+def test_match_rejects_outcome_before_candidate():
+    cand = _cand(ts="2026-06-02T10:00:00+00:00")
+    outcomes = [_out(ts="2026-06-02T09:00:00+00:00")]  # before the recall
+    assert R.match_outcome(cand, outcomes, window_seconds=86400) is None
+
+
+def test_match_rejects_outside_window():
+    cand = _cand(ts="2026-06-02T10:00:00+00:00")
+    outcomes = [_out(ts="2026-06-05T10:00:00+00:00")]  # 3 days later
+    assert R.match_outcome(cand, outcomes, window_seconds=3600) is None
+
+
+def test_match_picks_earliest_following_outcome():
+    cand = _cand(ts="2026-06-02T10:00:00+00:00")
+    outcomes = [
+        _out(ts="2026-06-02T12:00:00+00:00", success=False),
+        _out(ts="2026-06-02T10:30:00+00:00", success=True),  # earliest after
+    ]
+    m = R.match_outcome(cand, outcomes, window_seconds=86400)
+    assert m["ts"] == "2026-06-02T10:30:00+00:00"
+    assert m["success"] is True
+
+
+# --------------------------------------------------------- candidate_key
+def test_candidate_key_stable_and_distinct():
+    a = R.candidate_key(_cand(memory="m1.md"))
+    b = R.candidate_key(_cand(memory="m1.md"))
+    c = R.candidate_key(_cand(memory="m2.md"))
+    assert a == b
+    assert a != c
+
+
+# ----------------------------------------------- reconcile (emit_full lands)
+def _write_memory(tmp_path: Path, name="m.md", drift="green", creator="someone-else"):
+    p = tmp_path / name
+    p.write_text(
+        f"---\nname: x\ntype: reference\ndrift: {drift}\nagent_type: {creator}\n---\n\nbody\n",
+        encoding="utf-8")
+    return p
+
+
+def test_reconcile_settles_match_and_updates_cumulative_impact(tmp_path):
+    mem = _write_memory(tmp_path, name="m.md")
+    cands = [_cand(memory="m.md", actor="kairos")]
+    outs = [_out(agent_id="kairos", success=True)]
+    res = R.reconcile(cands, outs, settled_keys=set(), window_seconds=86400,
+                      memory_root=tmp_path, cache_dir=tmp_path)
+    assert res["settled"] == 1
+    # cumulative_impact frontmatter now present + positive (success outcome)
+    txt = mem.read_text(encoding="utf-8")
+    assert "cumulative_impact:" in txt
+    assert "impact_event_count: 1" in txt
+
+
+def test_reconcile_idempotent_via_settled_keys(tmp_path):
+    _write_memory(tmp_path, name="m.md")
+    cands = [_cand(memory="m.md", actor="kairos")]
+    outs = [_out(agent_id="kairos", success=True)]
+    seen = set()
+    r1 = R.reconcile(cands, outs, settled_keys=seen, window_seconds=86400,
+                     memory_root=tmp_path, cache_dir=tmp_path)
+    assert r1["settled"] == 1
+    # second pass with the same settled_keys must not re-settle
+    r2 = R.reconcile(cands, outs, settled_keys=seen, window_seconds=86400,
+                     memory_root=tmp_path, cache_dir=tmp_path)
+    assert r2["settled"] == 0
+    assert r2["skipped_already"] == 1
+
+
+def test_reconcile_no_match_does_not_settle(tmp_path):
+    _write_memory(tmp_path, name="m.md")
+    cands = [_cand(memory="m.md", actor="kairos")]
+    outs = [_out(agent_id="v7-telegram", success=True)]  # different actor
+    res = R.reconcile(cands, outs, settled_keys=set(), window_seconds=86400,
+                      memory_root=tmp_path, cache_dir=tmp_path)
+    assert res["settled"] == 0
+    assert res["skipped_no_match"] == 1
+
+
+def test_reconcile_failure_outcome_gives_negative_impact(tmp_path):
+    mem = _write_memory(tmp_path, name="m.md")
+    cands = [_cand(memory="m.md", actor="kairos")]
+    outs = [_out(agent_id="kairos", success=False)]
+    R.reconcile(cands, outs, settled_keys=set(), window_seconds=86400,
+                memory_root=tmp_path, cache_dir=tmp_path)
+    txt = mem.read_text(encoding="utf-8")
+    # failure outcome -> negative cumulative_impact
+    line = [l for l in txt.splitlines() if l.startswith("cumulative_impact:")][0]
+    val = float(line.split(":", 1)[1])
+    assert val < 0


### PR DESCRIPTION
## Summary

Elevates the L1-L4 memory substrate. All phases TDD'd in an isolated worktree; **667 tests pass**.

- **P1 · README honesty** (`e106215`): drop the L3-lifecycle over-claim — the tier-promotion/`forget_at` machinery is shipped + unit-tested but the production recall path does not promote tiers at query time (verified: `promote_lifecycle_tier()` called only from tests). Codex draft synced.
- **P2 · L4 cross-agent poller** (`f553b06`, `6a59ee1`, `4aa845d`): `ops/cross_agent_outcome_poller.py` — read-only subscribe to platform `engine_cycle_outcomes` + `agent_tool_calls` (compass_sub via ssh tunnel) → compass-recallable `session_*.md` + per-agent drift rollup. End-to-end verified against the real DB. b2 (125k rows) aggregated into one rollup (anti-flood). Writes to a dedicated `_l4_cross_agent` dir.
- **P3 · L2 metamemory** (`64af91b`): the `metamemory/` primitives existed but were never wired into recall. `build_recall_result` + `format_metamemory_notice` now fire on the daemon recall path (empty/weak recall → explicit "no reliable evidence" notice = hallucinate-absence cure). Pluggable LLM backend, default deterministic (black-box moat preserved).
- **P5 · L3 PoI closed loop** (`ff18bb2`, plus path B): root-caused L3's "0 events" — `emit_poi_candidate` fired only on the inline recall path, not the production daemon path, and no reconciler existed. Added daemon candidate-firing + `proof/poi_reconciler.py` (candidate × outcome → `cumulative_impact`). **E2E verified with real data**: recall→candidate→outcome→reconcile→`cumulative_impact=0.3333`→`boost_top_k` uses it. Path B (`proof/local_outcomes.py`) lets local recalls self-settle from the user's own session drift signal, no platform agent required.

## Notable findings
- Repeatedly, the substrate was already built but **dormant** (L2 metamemory, lifecycle, PoI) — the work was wiring + closing loops, not greenfield.
- Integration verification caught 3 bugs unit tests missed: `client_encoding=UTF8` (Chinese data), `ship_status` is the health signal (sem/tests_pass are NULL in prod), candidate emission not on the daemon path.

## Activation note (not in this PR)
Merging does NOT change production — the live daemon runs the plugin copy. Activating L2 + L3 candidate firing requires ff-ing the plugin + a daemon restart, done as a separate deliberate step. L3 settlement also needs recall-side demand (platform agents calling recall with `COMPASS_AGENT_ID` set) — tracked separately.

## Test plan
- [x] `pytest` — 667 passed
- [x] L4 poller dry-run + real run against DB (idempotent, dedicated dir)
- [x] L3 reconciler e2e with real kairos outcomes (cumulative_impact lands, boost applies)
- [ ] Post-merge: ff plugin + restart daemon → confirm production `poi_candidates.jsonl` fires
- [ ] Schedule L4 poller (`ops/setup-l4-poller-task.ps1`) when desired