### PR TITLE
PoI central-ledger Phase 1 (Option C · MVP single-table)

### DIFF
--- a/bin/cli_self_evolve.py
+++ b/bin/cli_self_evolve.py
@@ -14,7 +14,6 @@ Exit code 0 if any project was evolved, else 2.
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 from pathlib import Path
 

--- a/docs/plans/2026-06-03-poi-central-ledger-design.md
+++ b/docs/plans/2026-06-03-poi-central-ledger-design.md
@@ -1,0 +1,161 @@
+# PoI 信用跨主机累积 · 中央表(Option C · MVP 单表)
+
+> 设计日期 2026-06-03 · 接 P5(`2026-06-03-p5-v14-poi-emission-design.md`)收尾
+> 经 brainstorming(6 决策)+ 3 视角对抗审查(架构一致性 / failure·安全 / YAGNI)定稿
+> 状态:design approved · 下一步 writing-plans
+
+## 1. 问题
+
+PoI(Proof of Impact)信用闭环:memory 被召回 → agent 行动成功 → 该 memory 累积信用 → 未来召回时 boost 排名。
+
+当前信用存在 memory 文件的 YAML frontmatter(`cumulative_impact` 字段),**跟文件物理位置绑死**。但闭环天然跨主机:
+
+- recall:任意 daemon(本地 9876 / 云端 8770)
+- outcome:云端 postgres `agent_tool_calls`
+- **credit:写本地文件 frontmatter → 锁死文件所在主机**
+- boost:读文件的那个 daemon
+
+V5 召回打云端 daemon、outcome 在云端、但本地 reconciler 的 `MEMORY_ROOT` 是本地 → 碰不到云端 memory → M1 guard(文件存在才 settle)挡住 → **settled=0,信用永不累积**。
+
+根因:**信用是图属性(memory X 帮了 agent Y),却存成主机本地副产物,agent / 主机越多越断。**
+
+## 2. 目标
+
+1. 信用的权威载体放到云端一张表,任意主机的 reconcile 都往这张表累加
+2. 本地 boost 时拿到这张表的值(~0ms,不依赖 DB 可用性)
+3. 顺带让 L4「跨 agent 信用全局可见」白送(`SELECT … ORDER BY impact` 即全局视图)
+
+## 3. 决策汇总(brainstorming + 审查重裁)
+
+| # | 决策 | 说明 |
+|---|---|---|
+| 1 | `memory_key = project/filename` | 如 `C--Users-chunx/session_x.md`,防跨 project 短名碰撞 |
+| 2 | **单表 MVP**(审查重裁) | 砍 ledger 明细 / recompute / distinct_consumers。boost 只读一个标量,明细已有两份(`poi_events.jsonl` + 云端 `agent_tool_calls`),L4「谁受益」可 join `agent_tool_calls` |
+| 3 | 快照 cache | reconciler 现有 DB 连接顺手 `SELECT` 出 dict,~0ms boost,DB 挂了 daemon 照常跑 |
+| 4 | 设计含两侧 · 实现分两期 | Phase 1 本地(不动 live)/ Phase 2 云端 daemon boost |
+| 5 | **迁移砍**(审查重裁) | 从零累积(几天 reconcile 长回来);关键召回锚点可手动 INSERT 几行 |
+| 6 | **写角色简化**(审查重裁) | Phase 1 复用现有连接加单表写权;Phase 2 再建 `poi_writer` 专用角色收紧 |
+
+被否方案(记录避免重提):A 云端再跑一个 reconciler 写云端文件(治标,留 2-reconciler + 文件锁死债);B 每 daemon 一个信用 side-store(半步解耦)。
+
+## 4. 架构
+
+```
+┌─ emission(已 LIVE,本设计加 project 字段)
+│   本地 recall → poi_candidates.jsonl {ts,kind,actor,project,memory,query_hash,rank,score}
+│   云端 /v1/v14/recall → 同 schema(inline 自包含副本)
+│
+├─ reconcile(本地跑,持云端 DB 连接)
+│   load candidates → fetch outcomes(agent_tool_calls)→ match(24h 窗 + actor)
+│   → settled_keys 去重 → UPSERT compass.poi_credit(累加)→ 导出快照(原子写)
+│
+└─ boost(本地 daemon 9876)
+    boost_top_k:查内存 cache dict[memory_key] → miss 回退 frontmatter(过渡)
+    → NaN/异常兜底裸 cosine
+```
+
+### 4.1 表(放进现有 `compass` schema)
+
+```sql
+CREATE TABLE IF NOT EXISTS compass.poi_credit (
+    memory_key        text PRIMARY KEY,            -- project/filename
+    cumulative_impact double precision NOT NULL DEFAULT 0,
+    event_count       int NOT NULL DEFAULT 0,
+    last_impact_at    timestamptz
+);
+```
+
+settle 时(替代 `update_frontmatter_cumulative`):
+
+```sql
+INSERT INTO compass.poi_credit (memory_key, cumulative_impact, event_count, last_impact_at)
+VALUES (:mk, :delta, 1, :now)
+ON CONFLICT (memory_key) DO UPDATE
+SET cumulative_impact = compass.poi_credit.cumulative_impact + EXCLUDED.cumulative_impact,
+    event_count       = compass.poi_credit.event_count + 1,
+    last_impact_at     = EXCLUDED.last_impact_at;
+```
+
+`impact` delta 计算不变:`outcome_weight × cite_factor × drift_penalty`(`poi_calculator.py`)。
+
+### 4.2 幂等(单表方案的关键)
+
+累加 UPSERT 本身不幂等(重跑会双计)。Phase 1 靠 reconciler 现有 `settled_keys`(`candidate_key(actor, memory_key, query_hash)`)去重:**check settled → 未 settled 才 UPSERT + 记 settled + save**。
+
+- 边界:`settled_keys.json` 是本地 per-host + 有 5000 截断。**删除 / 截断淘汰会导致重算双计**。文档标注「勿删」。
+- Phase 1 只有本地一个 reconciler,该假设成立。
+- Phase 2 若云端也跑 reconciler → 加云端极简幂等键表(单列 UNIQUE,非明细账本)替代本地 json。
+
+`candidate_key` 三元组的 `memory` 必须同步改成 `memory_key`(含 project),与未来 DB 约束口径一致。
+
+### 4.3 快照
+
+reconciler UPSERT 后顺手 `SELECT memory_key, cumulative_impact FROM compass.poi_credit` → 写 `poi_credit_cache.json`(dict)。
+
+- **原子写**:`tmp → fsync → os.replace`(现有 `save_settled` 是非原子直写,不可沿用)
+- daemon 启动 + mtime 定期 reload 进内存;**reload 失败保留旧内存 dict,不清空**
+- 大小上限校验,超限 / 损坏退回旧 dict
+
+## 5. 横切 P0(三方审查命中,无论方案都纳入)
+
+1. **`derive_memory_key(project, filename)` 单一函数** — 当前 candidate 只带纯文件名,project 不在数据里(reconciler 环境变量隐式注入)。三处(本地 emit / 云端 inline 副本 / boost 查表)调同一函数 + 契约测试钉死「本地与云端副本同输入同输出」。candidate JSONL 加 `project` 字段,`pull_cloud_candidates.py` 透传。
+2. **NaN/inf 兜底** — `float("nan")` 不抛异常,`clamp(nan)` 污染,`sort` 用 NaN 比较打乱整个 top-K。`_parse_cumulative_impact` 后 `if not math.isfinite(v): return 0.0`;boost 后 `if not math.isfinite(boosted): boosted = cosine`。clamp `[-0.5, +1.0]` floor/cap 随快照迁移并单测钉死。
+3. **快照原子写** — 见 4.3。
+4. **M1 guard 语义迁移** — 现「本地文件存在才 settle」会让只存在于云端的 memory 永远 `exists()==False` → 复活 settled=0。settle 真相落点从 frontmatter 改为 DB UPSERT;幂等护栏从文件系统移到 settled_keys(Phase 1)/ 云端键表(Phase 2)。文件存在与否不再是 settle 前置条件。
+5. **self-cite 抑制迁移** — 现靠读本地 frontmatter 的 creator 比对。frontmatter 停写后失效 → agent 自引自造 memory 无限刷分。creator 进 candidate;settle 端 `consumer != creator` 过滤。
+6. **刷分防护** — outcome 只由 reconciler 从可信源(`agent_tool_calls.success` / 本地 session drift)派生,写入端不接受调用方自报 outcome。
+
+## 6. Phase 划分
+
+### Phase 1(本轮实现,不动 live)
+
+落地面:1 SQL + 3 代码接缝 + 1 快照导出。
+
+| 件 | 文件 | 改动 |
+|---|---|---|
+| SQL | `sql/004_poi_credit.sql` | 建 `compass.poi_credit` + grant 现有可写账户 |
+| emission | `proof/poi_emitter.py::emit_poi_candidate` + 云端 inline patch | candidate 加 `project` 字段 |
+| reconcile | `ops/poi_reconcile_cron.py` + `proof/poi_reconciler.py` | settled_keys 去重 → UPSERT 云表(停 `update_frontmatter`)→ 导快照(原子);M1 guard 语义改;candidate_key 含 project |
+| boost | `recall_pkg/poi_weighting.py::boost_top_k` | 查 cache dict(`.get(mk, 0.0)`)→ miss 回退 frontmatter(过渡双读)→ NaN/异常兜底 |
+| derive | 新 `derive_memory_key` 工具 | 单一来源 + 契约测试 |
+
+**验证**:本地 dialog recall 被 boost · 端到端 settled > 0 · 重跑 reconcile 不双计。
+
+**诚实边界**:Phase 1 后 **V5 云端召回尚未被 boost**(云端 daemon 不读快照)。L3 对本地闭、对 V5 待 Phase 2。明告 V5。
+
+### Phase 2(下轮,动 live 端点,单独验证回滚)
+
+| 件 | 改动 |
+|---|---|
+| 快照上云 | reconciler scp 快照 → **`/var/lib/compass/poi/`(sandbox 白名单)** + ssh 回读 `test -s` + `json.load` 校验非空可解析才触发 reload |
+| 云端 boost | `compass_http_v09.py` 8770 接 boost:**后台线程 reload + 原子指针 swap · 零共享锁**;recall 热路径只读已加载 dict;boost `try/except` 永不拖垮 V5 recall;env `COMPASS_CLOUD_POI_BOOST=0` 默认关,验证后开 |
+| 写角色 | 建 `poi_writer` 专用角色收紧权限;secret 复用 `.soul_db_secret` 模式(独立文件 600 + scp 传输,不 inline / log / git) |
+| 多主机幂等 | 云端幂等键表替代本地 settled_keys |
+
+**最高风险事故链(安全审查标的)**:scp 落非白名单 → `ProtectHome=read-only` 静默吞 → daemon reload 空 snapshot → reload 卡共享锁(无 swap 内存抖动旧伤)→ V5 全拒召回。三层防护:投放层(硬钉白名单 + 回读校验)/ 加载层(后台线程原子 swap,失败保留旧)/ 熔断层(boost try/except + 超时,异常返回裸 cosine)。改 live 文件只走部署 / patch 脚本,绝不 inline `python -c` 带 `\n`。
+
+## 7. 测试(TDD)
+
+- `derive_memory_key` 一致性(本地实现 ↔ 云端 inline 副本契约)
+- boost:cache 命中 / miss 回退 frontmatter / NaN / inf / 异常兜底裸 cosine / clamp floor-cap 钉死
+- 快照:原子写 / 损坏退回旧 dict / 缺失退不 boost / 大小上限
+- reconcile:UPSERT 累加正确 / settled_keys 幂等重跑不双计 / 停写 frontmatter / M1 语义(云端 memory 也能 settle)
+- self-cite:consumer == creator 被过滤
+- SQL:表 + grant 应用
+
+## 8. 错误处理
+
+- 快照缺失 / 损坏 → 不 boost(graceful,沿用 `COMPASS_NO_POI_BOOST` 兜底语义)
+- DB 写失败 → 不推进 settled_keys → 下个 cron 重试(幂等安全)
+- boost 任何异常 / 超时 → 返回裸 cosine,**recall 永不因 boost 失败而失败**(boost 是增强不是依赖)
+
+## 9. 关键文件
+
+- `proof/poi_emitter.py` — candidate schema 加 project、停写 frontmatter
+- `proof/poi_reconciler.py` — settle 落点、M1 guard、candidate_key 三元组、idempotency
+- `recall_pkg/poi_weighting.py` — boost 改查快照 + NaN/clamp 防护
+- `ops/poi_reconcile_cron.py` — UPSERT + 快照原子导出 + 连接复用
+- `ops/pull_cloud_candidates.py` — project 字段透传
+- `ops/patch_v14_recall_poi_candidate.py` — 云端 inline emission(derive_memory_key 契约另一端)
+- `sql/004_poi_credit.sql` — 新表 + grant
+- 参照 `ops/cross_agent_outcome_poller.py` — secret / 隧道 / 只读连接复用模板

--- a/docs/plans/2026-06-03-poi-central-ledger-implementation.md
+++ b/docs/plans/2026-06-03-poi-central-ledger-implementation.md
@@ -1,0 +1,631 @@
+# PoI 中央表 Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 把 PoI 信用从 memory 文件 frontmatter(主机绑死)迁到云端单表 `compass.poi_credit`,reconciler 累加、本地 daemon 读快照 boost,跨主机可累积。
+
+**Architecture:** 单表 `compass.poi_credit(memory_key, cumulative_impact, event_count, last_impact_at)`,`memory_key=project/filename`。reconciler settle 时 UPSERT 累加(替代 frontmatter 写入)并顺手导出快照 dict;`boost_top_k` 读快照内存 dict(~0ms),miss 回退 frontmatter(过渡双读)。Phase 1 不动 live 云端端点;幂等靠本地 `settled_keys`。
+
+**Tech Stack:** Python 3.11 · psycopg2(云端 pg via SSH 隧道)· pytest · sqlite(单测用,ON CONFLICT 兼容)。
+
+**设计依据:** `docs/plans/2026-06-03-poi-central-ledger-design.md`(6 决策 + 三方审查横切 P0)。
+
+**前置:** 工作分支 `feat/poi-central-ledger`(已基于 origin/main 6ab5c9b 建)。每个 Task 末尾 commit。
+
+---
+
+## Task 1: `derive_memory_key` 单一来源(纯函数 + 契约)
+
+横切 P0-1。三处(本地 emit / 云端 inline / boost / 迁移)必须用同一 key 派生,否则 join 不上。
+
+**Files:**
+- Create: `proof/poi_memory_key.py`
+- Test: `tests/test_poi_memory_key.py`
+
+**Step 1: 写失败测试**
+
+```python
+# tests/test_poi_memory_key.py
+from pathlib import Path
+from proof.poi_memory_key import derive_memory_key, memory_key_from_path
+
+def test_derive_basic():
+    assert derive_memory_key("C--Users-chunx", "session_x.md") == "C--Users-chunx/session_x.md"
+
+def test_derive_normalizes_raw_windows_project():
+    # 防御 V5 传未编码路径 C:\Users\chunx
+    assert derive_memory_key("C:\\Users\\chunx", "x.md") == "C--Users-chunx/x.md"
+
+def test_derive_strips_filename_dir():
+    # filename 只取 basename,防上游误传路径
+    assert derive_memory_key("proj", "memory/x.md") == "proj/x.md"
+
+def test_memory_key_from_full_path():
+    p = Path.home() / ".claude" / "projects" / "C--Users-chunx" / "memory" / "session_x.md"
+    assert memory_key_from_path(p) == "C--Users-chunx/session_x.md"
+
+def test_memory_key_from_path_filename_only_returns_none():
+    # 纯文件名无法定位 project → None(boost 侧据此回退 frontmatter)
+    assert memory_key_from_path("session_x.md") is None
+```
+
+**Step 2: 跑测试确认失败**
+
+Run: `cd /c/Users/chunx/Projects/nautilus-compass && python -m pytest tests/test_poi_memory_key.py -q`
+Expected: FAIL（ModuleNotFoundError: proof.poi_memory_key）
+
+**Step 3: 最小实现**
+
+```python
+# proof/poi_memory_key.py
+"""Single source of truth for PoI memory_key = project/filename.
+Used by emission (local + cloud inline copy), reconcile, boost, migration.
+Pure · no I/O on the derive path. Reference: docs/plans/2026-06-03-poi-central-ledger-design.md §5.
+"""
+from __future__ import annotations
+from pathlib import PurePosixPath, PureWindowsPath
+from typing import Optional
+
+
+def _normalize_project(project: str) -> str:
+    """Match recall.py encoded_cwd form: C:\\Users\\chunx -> C--Users-chunx."""
+    p = (project or "").strip()
+    if ":" in p or "\\" in p:
+        p = p.replace(":\\", "--").replace(":/", "--").replace("\\", "-").replace("/", "-")
+    return p
+
+
+def _basename(filename: str) -> str:
+    name = (filename or "").strip().replace("\\", "/")
+    return name.rsplit("/", 1)[-1]
+
+
+def derive_memory_key(project: str, filename: str) -> str:
+    return f"{_normalize_project(project)}/{_basename(filename)}"
+
+
+def memory_key_from_path(path) -> Optional[str]:
+    """Derive key from a memory file path .../projects/<project>/memory/<file>.
+    Returns None if path is just a filename (project undeterminable)."""
+    s = str(path).replace("\\", "/")
+    parts = s.split("/")
+    if len(parts) < 3:
+        return None  # filename only or too shallow
+    # <project>/memory/<file>  → project = parts[-3]
+    return derive_memory_key(parts[-3], parts[-1])
+```
+
+**Step 4: 跑测试确认通过**
+
+Run: `python -m pytest tests/test_poi_memory_key.py -q`
+Expected: PASS (5 passed)
+
+**Step 5: Commit**
+
+```bash
+git add proof/poi_memory_key.py tests/test_poi_memory_key.py
+git commit -m "feat(poi): derive_memory_key single source (P0-1)"
+```
+
+---
+
+## Task 2: `poi_credit_store` — UPSERT 累加 + 快照原子读写
+
+横切 P0-3(原子写)。可用 sqlite 单测(ON CONFLICT 与 pg 兼容),生产传 psycopg2 连接。
+
+**Files:**
+- Create: `proof/poi_credit_store.py`
+- Test: `tests/test_poi_credit_store.py`
+
+**Step 1: 写失败测试**
+
+```python
+# tests/test_poi_credit_store.py
+import json, sqlite3
+from pathlib import Path
+from proof.poi_credit_store import (
+    upsert_credit, fetch_all_credits, write_snapshot_atomic, load_snapshot,
+)
+
+CREATE_SQLITE = (
+    "CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, "
+    "cumulative_impact REAL NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0, "
+    "last_impact_at TEXT)"
+)
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    c.execute(CREATE_SQLITE)
+    return c
+
+def test_upsert_accumulates():
+    c = _conn()
+    upsert_credit(c, "proj/a.md", 0.5, "2026-06-03T00:00:00+00:00", placeholder="?")
+    upsert_credit(c, "proj/a.md", 0.3, "2026-06-03T01:00:00+00:00", placeholder="?")
+    row = c.execute("SELECT cumulative_impact, event_count FROM poi_credit WHERE memory_key='proj/a.md'").fetchone()
+    assert round(row[0], 4) == 0.8 and row[1] == 2
+
+def test_fetch_all_credits_dict():
+    c = _conn()
+    upsert_credit(c, "proj/a.md", 0.5, "t", placeholder="?")
+    upsert_credit(c, "proj/b.md", -0.2, "t", placeholder="?")
+    d = fetch_all_credits(c)
+    assert d == {"proj/a.md": 0.5, "proj/b.md": -0.2}
+
+def test_snapshot_atomic_roundtrip(tmp_path):
+    snap = tmp_path / "poi_credit_cache.json"
+    write_snapshot_atomic(snap, {"proj/a.md": 0.8})
+    # 原子:无 .tmp 残留
+    assert not list(tmp_path.glob("*.tmp"))
+    assert load_snapshot(snap) == {"proj/a.md": 0.8}
+
+def test_load_snapshot_missing_returns_empty(tmp_path):
+    assert load_snapshot(tmp_path / "nope.json") == {}
+
+def test_load_snapshot_corrupt_returns_empty(tmp_path):
+    p = tmp_path / "bad.json"; p.write_text("{not json", encoding="utf-8")
+    assert load_snapshot(p) == {}
+```
+
+**Step 2: 确认失败** — Run `python -m pytest tests/test_poi_credit_store.py -q` → FAIL（模块缺失）
+
+**Step 3: 最小实现**
+
+```python
+# proof/poi_credit_store.py
+"""Central PoI credit table I/O + atomic snapshot. Replaces frontmatter as the
+credit source of truth. Reference: design §4.1/§4.3. NO LLM."""
+from __future__ import annotations
+import json, os, tempfile
+from pathlib import Path
+from typing import Dict
+
+UPSERT_SQL = (
+    "INSERT INTO poi_credit (memory_key, cumulative_impact, event_count, last_impact_at) "
+    "VALUES ({p}, {p}, 1, {p}) "
+    "ON CONFLICT (memory_key) DO UPDATE SET "
+    "cumulative_impact = poi_credit.cumulative_impact + EXCLUDED.cumulative_impact, "
+    "event_count = poi_credit.event_count + 1, "
+    "last_impact_at = EXCLUDED.last_impact_at"
+)
+
+
+def upsert_credit(conn, memory_key: str, delta: float, now_iso: str, placeholder: str = "%s") -> None:
+    """Accumulate delta onto memory_key. placeholder='%s' for psycopg2, '?' for sqlite."""
+    sql = UPSERT_SQL.format(p=placeholder)
+    cur = conn.cursor()
+    cur.execute(sql, (memory_key, float(delta), now_iso))
+    conn.commit()
+
+
+def fetch_all_credits(conn) -> Dict[str, float]:
+    cur = conn.cursor()
+    cur.execute("SELECT memory_key, cumulative_impact FROM poi_credit")
+    return {k: float(v) for k, v in cur.fetchall()}
+
+
+def write_snapshot_atomic(path, credit: Dict[str, float]) -> None:
+    """tmp -> fsync -> os.replace · daemon never reads a half-written file."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(credit, f, ensure_ascii=False)
+            f.flush(); os.fsync(f.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def load_snapshot(path) -> Dict[str, float]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+```
+
+**Step 4: 确认通过** — `python -m pytest tests/test_poi_credit_store.py -q` → PASS
+
+**Step 5: Commit**
+
+```bash
+git add proof/poi_credit_store.py tests/test_poi_credit_store.py
+git commit -m "feat(poi): credit store UPSERT + atomic snapshot (P0-3)"
+```
+
+---
+
+## Task 3: `boost_top_k` 读快照 + NaN/clamp 兜底
+
+横切 P0-2。boost 改成先查快照 dict(key 由 entry 路径派生),miss 回退 frontmatter,NaN/inf 兜底裸 cosine。
+
+**Files:**
+- Modify: `recall_pkg/poi_weighting.py`
+- Test: `tests/test_poi_weighting_snapshot.py`
+
+**Step 1: 写失败测试**
+
+```python
+# tests/test_poi_weighting_snapshot.py
+import math
+from recall_pkg.poi_weighting import apply_poi_boost_value, boost_top_k_with_snapshot
+
+def test_apply_value_basic():
+    # cumulative=5 → boost=clamp(0.5)=0.5 → 0.8*1.5=1.2
+    assert round(apply_poi_boost_value(0.8, 5.0), 4) == 1.2
+
+def test_apply_value_clamp_cap():
+    # cumulative=100 → boost capped at +1.0 → 0.5*2.0=1.0
+    assert round(apply_poi_boost_value(0.5, 100.0), 4) == 1.0
+
+def test_apply_value_clamp_floor():
+    assert round(apply_poi_boost_value(0.5, -100.0), 4) == 0.25  # *0.5
+
+def test_apply_value_nan_returns_base():
+    assert apply_poi_boost_value(0.7, float("nan")) == 0.7
+    assert apply_poi_boost_value(0.7, float("inf")) == 0.7
+
+def test_boost_with_snapshot_reranks():
+    snap = {"proj/hi.md": 5.0}
+    top = [
+        (0.50, {"path": "x", "fullpath": "/h/.claude/projects/proj/memory/lo.md"}),
+        (0.45, {"path": "y", "fullpath": "/h/.claude/projects/proj/memory/hi.md"}),
+    ]
+    out = boost_top_k_with_snapshot(top, snap)
+    # hi.md boosted 0.45*1.5=0.675 > lo.md 0.50 → reranked to top
+    assert "hi.md" in out[0][1]["fullpath"]
+```
+
+**Step 2: 确认失败** — `python -m pytest tests/test_poi_weighting_snapshot.py -q` → FAIL
+
+**Step 3: 实现**（在 `recall_pkg/poi_weighting.py` 追加,保留现有 `apply_poi_boost`/`boost_top_k` 作回退）
+
+```python
+import math
+from .._compat_noop import noop  # if no such, skip; just add below to poi_weighting.py
+from proof.poi_memory_key import memory_key_from_path
+
+def apply_poi_boost_value(cosine_score: float, cumulative: float,
+                          boost_factor: float = BOOST_FACTOR_DEFAULT) -> float:
+    """Boost from a raw cumulative value (snapshot path). NaN/inf-safe."""
+    if not math.isfinite(cumulative):
+        return cosine_score
+    boost = max(BOOST_FLOOR, min(BOOST_CAP, cumulative * boost_factor))
+    out = cosine_score * (1.0 + boost)
+    return out if math.isfinite(out) else cosine_score
+
+def boost_top_k_with_snapshot(top_entries: list, snapshot: dict,
+                              boost_factor: float = BOOST_FACTOR_DEFAULT) -> list:
+    """Re-rank using central-credit snapshot dict (memory_key -> cumulative).
+    Miss → fall back to frontmatter read (transition). Never raises."""
+    boosted = []
+    for score, entry in top_entries:
+        if not isinstance(entry, dict):
+            boosted.append((score, entry)); continue
+        path = entry.get("fullpath") or entry.get("path") or ""
+        mk = memory_key_from_path(path) if path else None
+        if mk is not None and mk in snapshot:
+            new_score = apply_poi_boost_value(score, snapshot[mk], boost_factor)
+        else:
+            front = parse_session_frontmatter_safe(path) if path else {}
+            new_score = apply_poi_boost(score, front, boost_factor=boost_factor)
+        boosted.append((new_score, entry))
+    boosted.sort(key=lambda x: x[0], reverse=True)
+    return boosted
+```
+
+> 注意:删掉示例里不存在的 `from .._compat_noop import noop` 行,只保留 `import math` 与 `from proof.poi_memory_key import memory_key_from_path`(放文件顶部 import 区)。
+
+**Step 4: 确认通过** — `python -m pytest tests/test_poi_weighting_snapshot.py -q` → PASS
+
+**Step 5: Commit**
+
+```bash
+git add recall_pkg/poi_weighting.py tests/test_poi_weighting_snapshot.py
+git commit -m "feat(poi): boost reads credit snapshot + NaN/clamp guard (P0-2)"
+```
+
+---
+
+## Task 4: candidate emission 加 `project` + `creator`(本地)
+
+横切 P0-1 / P0-5。本地 `emit_poi_candidate` 写 candidate 时带 project(从路径派生)与 creator(frontmatter,已读)。
+
+**Files:**
+- Modify: `proof/poi_emitter.py:151-203`（`emit_poi_candidate`）
+- Test: `tests/test_poi_candidate_project.py`
+
+**Step 1: 写失败测试**
+
+```python
+# tests/test_poi_candidate_project.py
+import json
+from pathlib import Path
+from proof.poi_emitter import emit_poi_candidate
+
+def test_candidate_carries_project_and_creator(tmp_path):
+    mem = tmp_path / "projects" / "C--Users-chunx" / "memory" / "m.md"
+    mem.parent.mkdir(parents=True)
+    mem.write_text("---\nagent_type: other-agent\n---\nbody", encoding="utf-8")
+    top = [(0.9, {"fullpath": str(mem), "path": "m.md"})]
+    n = emit_poi_candidate(top, query="q", agent_id="me", cache_dir=tmp_path)
+    line = json.loads((tmp_path / "poi_candidates.jsonl").read_text().splitlines()[0])
+    assert n == 1
+    assert line["project"] == "C--Users-chunx"
+    assert line["memory"] == "m.md"
+    assert line["creator"] == "other-agent"
+```
+
+**Step 2: 确认失败** → FAIL（无 project 字段）
+
+**Step 3: 实现** — 在 `emit_poi_candidate` 写 JSONL 处加字段。当前 line 193-201 的 dict 改为:
+
+```python
+            front = parse_session_frontmatter_safe(path)
+            creator = front.get("agent_type", "") or front.get("agent_id", "")
+            if SUPPRESS_SELFCITE and agent_id and creator == agent_id:
+                continue
+            from proof.poi_memory_key import memory_key_from_path, derive_memory_key
+            mk = memory_key_from_path(path)
+            project = mk.split("/", 1)[0] if mk else os.environ.get("COMPASS_PROJECT_NS", "")
+            f.write(json.dumps({
+                "ts": ts, "kind": "candidate", "actor": actor,
+                "project": project, "memory": path.name, "creator": creator,
+                "query_hash": q_hash, "rank": rank, "score": round(float(score), 4),
+            }, ensure_ascii=False) + "\n")
+```
+
+> 把原先单独的 self-cite 块(line 186-192)合并进上面(避免重复读 frontmatter)。
+
+**Step 4: 确认通过** + 回归 `python -m pytest tests/test_poi_emitter.py -q`（确认旧测试不破）
+
+**Step 5: Commit**
+
+```bash
+git add proof/poi_emitter.py tests/test_poi_candidate_project.py
+git commit -m "feat(poi): local candidate carries project+creator (P0-1/P0-5)"
+```
+
+---
+
+## Task 5: 云端 inline helper 加 `project` 参数(patch)
+
+横切 P0-1 契约另一端。云端 `_v14_emit_poi_candidate` 从 v14 recall 的 `project` query 参数取(V5 已传)。沿用现有 exec 契约测试模式。
+
+**Files:**
+- Modify: `ops/patch_v14_recall_poi_candidate.py`（`EMIT_HELPER` 常量 + 注入点传 project）
+- Test: `tests/test_v14_poi_emission_patch.py`（已存在 · 加断言)
+
+**Step 1: 加失败断言** — 在现有 exec 测试里断言输出行含 `"project"`,且 helper 签名为 `_v14_emit_poi_candidate(hits, query, agent_id, project)`。
+
+**Step 2: 确认失败**
+
+**Step 3: 实现** — `EMIT_HELPER` 签名加 `project`,写入 dict 加 `"project": project`(helper 内对 project 做同样规范化:`if ":" in project or "\\\\" in project` 则 replace);注入到 v14_recall 的调用点把 `project` 实参传进去(recall 路由已有 project 变量)。
+
+**Step 4: 确认通过** — `python -m pytest tests/test_v14_poi_emission_patch.py -q`
+
+**Step 5: Commit**
+
+```bash
+git add ops/patch_v14_recall_poi_candidate.py tests/test_v14_poi_emission_patch.py
+git commit -m "feat(poi): cloud inline emit carries project (P0-1 contract)"
+```
+
+> ⚠️ 本 Task 只改 patch 脚本 + 测试 · **不部署到云端**(Phase 1 不动 live)。部署在 Phase 2。
+
+---
+
+## Task 6: reconciler 改用 memory_key + 中央表 credit + 松绑 M1
+
+横切 P0-4。`reconcile` 用 memory_key 做 key,credit 写中央表(替代 frontmatter),M1 不再以本地文件存在为 settle 前置,self-cite 用 candidate 的 creator DB 侧过滤。
+
+**Files:**
+- Modify: `proof/poi_reconciler.py:62-67`（candidate_key）, `:126-174`（reconcile）
+- Test: `tests/test_poi_reconciler_central.py`
+
+**Step 1: 写失败测试**
+
+```python
+# tests/test_poi_reconciler_central.py
+import sqlite3
+from proof.poi_reconciler import reconcile_central
+
+CREATE = ("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, cumulative_impact REAL "
+          "NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+
+def _conn():
+    c = sqlite3.connect(":memory:"); c.execute(CREATE); return c
+
+def _cand(actor="a1", project="proj", memory="m.md", creator="other", ts="2026-06-03T00:00:00+00:00", qh="q"):
+    return {"kind": "candidate", "actor": actor, "project": project, "memory": memory,
+            "creator": creator, "query_hash": qh, "ts": ts, "rank": 0, "score": 0.9}
+
+def test_settle_writes_central_no_file_needed():
+    # 云端 memory · 本地无文件 · 仍 settle(M1 松绑)
+    conn = _conn(); settled = set()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([_cand()], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    assert r["settled"] == 1
+    row = conn.execute("SELECT cumulative_impact FROM poi_credit WHERE memory_key='proj/m.md'").fetchone()
+    assert row and row[0] > 0
+
+def test_rerun_idempotent_no_double_count():
+    conn = _conn(); settled = set()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    reconcile_central([_cand()], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    reconcile_central([_cand()], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    row = conn.execute("SELECT event_count FROM poi_credit WHERE memory_key='proj/m.md'").fetchone()
+    assert row[0] == 1  # 第二次被 settled_keys 挡住
+
+def test_selfcite_dropped():
+    conn = _conn(); settled = set()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([_cand(creator="a1")], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    assert r["settled"] == 0 and r.get("skipped_selfcite") == 1
+```
+
+**Step 2: 确认失败** → FAIL（`reconcile_central` 缺失）
+
+**Step 3: 实现** — 新增 `reconcile_central`(不删旧 `reconcile`,保留兼容)。key 用 `derive_memory_key(cand["project"], cand["memory"])`;credit 走 `upsert_credit`;不查文件存在;creator==actor 跳过并计 `skipped_selfcite`。impact 用现有 `compute_with_drift`(memory_root 可为 None → drift_penalty 默认 1.0)。
+
+```python
+from .poi_memory_key import derive_memory_key
+from .poi_credit_store import upsert_credit
+from datetime import datetime, timezone
+
+def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
+                      window_seconds=DEFAULT_WINDOW_S, placeholder="%s"):
+    if settled_keys is None:
+        settled_keys = set()
+    settled = skipped_no_match = skipped_already = skipped_selfcite = 0
+    for cand in candidates:
+        mk = derive_memory_key(cand.get("project", ""), cand.get("memory", ""))
+        key = candidate_key({**cand, "memory": mk})  # key now includes project
+        if key in settled_keys:
+            skipped_already += 1; continue
+        if cand.get("creator") and cand.get("creator") == cand.get("actor"):
+            skipped_selfcite += 1; continue
+        outcome = match_outcome(cand, outcomes, window_seconds=window_seconds)
+        if outcome is None:
+            skipped_no_match += 1; continue
+        poi = ProofOfImpact(
+            action_id=f"recon-{key}", agent_id=cand["actor"], cited_memory_paths=[cand["memory"]],
+            action_outcome=outcome_to_action_outcome(outcome),
+            timestamp_action=str(cand.get("ts", "")), timestamp_outcome=str(outcome.get("ts", "")),
+            notes=f"central reconcile {cand['actor']}")
+        compute_with_drift(poi, memory_root=None)
+        now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        upsert_credit(conn, mk, poi.impact_score, now_iso, placeholder=placeholder)
+        settled_keys.add(key); settled += 1
+    return {"settled": settled, "skipped_no_match": skipped_no_match,
+            "skipped_already": skipped_already, "skipped_selfcite": skipped_selfcite}
+```
+
+> `candidate_key` 现用 `cand["memory"]`;此处传入已是 memory_key,三元组 `(actor, memory_key, query_hash)` 与未来 DB 约束口径一致(P1-3)。
+
+**Step 4: 确认通过** — `python -m pytest tests/test_poi_reconciler_central.py -q`(3 passed)+ 回归 `tests/test_poi_reconciler.py`(旧 reconcile 不破)
+
+**Step 5: Commit**
+
+```bash
+git add proof/poi_reconciler.py tests/test_poi_reconciler_central.py
+git commit -m "feat(poi): reconcile_central → poi_credit, relax M1, DB self-cite (P0-4/5)"
+```
+
+---
+
+## Task 7: SQL 004 建表 + grant
+
+**Files:**
+- Create: `sql/004_poi_credit.sql`
+- Test: `tests/test_sql_004_applies.py`(用 sqlite 跑 schema 段,验证语法可建表)
+
+**Step 1: 写失败测试** — 加载 `sql/004_poi_credit.sql` 里 `CREATE TABLE` 段在 sqlite 跑通(grant 段单独标记跳过 sqlite)。
+
+**Step 2: 确认失败**
+
+**Step 3: 实现**
+
+```sql
+-- sql/004_poi_credit.sql · PoI central credit table (Option C · MVP single-table)
+-- Reference: docs/plans/2026-06-03-poi-central-ledger-design.md §4.1
+CREATE TABLE IF NOT EXISTS compass.poi_credit (
+    memory_key        text PRIMARY KEY,
+    cumulative_impact double precision NOT NULL DEFAULT 0,
+    event_count       int NOT NULL DEFAULT 0,
+    last_impact_at    timestamptz
+);
+-- Phase 1: reuse existing writable account (the schema-owner used for deploys).
+-- Phase 2 will introduce a dedicated poi_writer role and tighten this grant.
+GRANT SELECT, INSERT, UPDATE ON compass.poi_credit TO compass_sub;  -- TODO Phase 2: move to poi_writer
+```
+
+> ⚠️ grant 给 compass_sub 写权是 Phase 1 简化(决策 6)· Phase 2 收紧到 poi_writer。应用到云端 DB 需用户/部署账户跑(本 Task 只入库 SQL 文件,不连云改库)。
+
+**Step 4: 确认通过**
+
+**Step 5: Commit**
+
+```bash
+git add sql/004_poi_credit.sql tests/test_sql_004_applies.py
+git commit -m "feat(poi): sql 004 poi_credit table + phase1 grant"
+```
+
+---
+
+## Task 8: cron 接线 — UPSERT + 快照导出(连接复用)
+
+把 `reconcile_central` 接进 `ops/poi_reconcile_cron.py`:复用现有 DB 连接(读 outcome 那条),settle 后 `fetch_all_credits` → `write_snapshot_atomic`。
+
+**Files:**
+- Modify: `ops/poi_reconcile_cron.py`
+- Test: `tests/test_poi_reconcile_cron_wire.py`(mock DB 连接 + tmp 快照,验证流程:load candidates → reconcile_central → 导快照文件存在且含 settle 的 key)
+
+**Step 1: 写失败测试** — 用 sqlite 连接 + 假 candidates/outcomes 跑 cron 的 `run_once(conn, ...)` 入口,断言快照文件落地且 boost 能读。
+
+**Step 2-4:** 实现 `run_once`:`load_candidates` → `load_settled` → `reconcile_central(conn=...)` → `save_settled` → `fetch_all_credits` → `write_snapshot_atomic(snapshot_path, credits)`。snapshot_path 默认 `DEFAULT_CACHE_DIR / "poi_credit_cache.json"`(env `COMPASS_POI_CREDIT_SNAPSHOT` 覆盖)。生产 placeholder='%s'。
+
+**Step 5: Commit**
+
+```bash
+git add ops/poi_reconcile_cron.py tests/test_poi_reconcile_cron_wire.py
+git commit -m "feat(poi): cron wires reconcile_central + atomic snapshot export"
+```
+
+---
+
+## Task 9: daemon boost 接快照(读端接线)+ 全量回归
+
+把 daemon 召回路径(`recall.py:1010` 的 `boost_top_k(top)`)换成读快照的 `boost_top_k_with_snapshot`,快照用 mtime 缓存懒加载。
+
+**Files:**
+- Modify: `recall.py:1006-1014`（boost 调用点)
+- Create: `recall_pkg/poi_snapshot_cache.py`（mtime 懒加载单例:`get_credit_snapshot()`）
+- Test: `tests/test_poi_snapshot_cache.py`(mtime 变 → reload;损坏 → 保留旧)
+
+**Step 1: 写失败测试** — `get_credit_snapshot()` 首次读文件;文件 mtime 不变时不重读;mtime 变重读;损坏时返回上次好的 dict。
+
+**Step 2-4:** 实现懒加载缓存,recall.py 调用点改:
+```python
+if os.environ.get("COMPASS_NO_POI_BOOST") != "1":
+    try:
+        from recall_pkg.poi_weighting import boost_top_k_with_snapshot
+        from recall_pkg.poi_snapshot_cache import get_credit_snapshot
+        top = boost_top_k_with_snapshot(top, get_credit_snapshot())
+    except Exception:
+        pass  # boost is enhancement · never fail recall (design §8)
+```
+
+**Step 5: Commit + 全量回归**
+
+```bash
+python -m pytest -q   # 全绿
+git add recall.py recall_pkg/poi_snapshot_cache.py tests/test_poi_snapshot_cache.py
+git commit -m "feat(poi): daemon boost reads credit snapshot (mtime lazy cache)"
+```
+
+---
+
+## Task 10: 端到端验证(verification-before-completion)
+
+REQUIRED SUB-SKILL: superpowers:verification-before-completion。**不实测不宣告完成。**
+
+1. **本地全绿**:`python -m pytest -q` → 0 fail(记录数字)。
+2. **DB 建表**:在云端 pg 应用 `sql/004_poi_credit.sql`(用户/部署账户;隧道连 `nautilus_production`)→ `\dt compass.poi_credit` 确认存在。
+3. **reconcile 真跑**:`python ops/poi_reconcile_cron.py`(或 scheduled task `compass-poi-reconcile`)→ 拉云 candidate + 隧道连 DB → 断言 `settled > 0`(用真 nautilus-prime-001 流量)→ `SELECT * FROM compass.poi_credit ORDER BY cumulative_impact DESC LIMIT 5` 看真值落库。
+4. **快照落地**:`poi_credit_cache.json` 存在 + 含 settle 的 memory_key。
+5. **boost 生效**:本地 daemon 重启 → 召回一个高 credit memory 的 query → 确认排名被提升(对比 `COMPASS_NO_POI_BOOST=1` 基线)。
+6. **重跑不双计**:再跑一次 reconcile → `event_count` 不重复增长。
+
+全部通过才标 Phase 1 done。**诚实边界**:V5 云端召回 Phase 1 仍未 boost(Phase 2),如实告知 V5(`cnt_compass_v5_recall_demand_c1`)。
+
+---
+
+## Phase 1 完成后 → finishing-a-development-branch
+
+REQUIRED SUB-SKILL: superpowers:finishing-a-development-branch(决定 merge/PR)。Phase 2(快照上云 + 云端 daemon boost + poi_writer + 多主机幂等)另起 session,见 design §6 Phase 2。

--- a/metamemory/builder.py
+++ b/metamemory/builder.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from typing import Any, Callable, Dict, List, Optional
 
 from metamemory.confidence import ConfidenceVector
-from metamemory.gap import GapStatement
 from metamemory.gap_detector import detect_gaps
 from metamemory.calibration import calibration_score
 from metamemory.result import RecallResult

--- a/ops/cross_agent_outcome_poller.py
+++ b/ops/cross_agent_outcome_poller.py
@@ -300,8 +300,11 @@ def save_watermark(path: str, wm: dict) -> None:
 
 # ------------------------------------------------------------------ db layer
 @contextmanager
-def db_connection(cfg: dict, local_port: int = LOCAL_PORT):
-    """Open ssh tunnel + psycopg2 read-only connection · tear both down."""
+def db_connection(cfg: dict, local_port: int = LOCAL_PORT, readonly: bool = True):
+    """Open ssh tunnel + psycopg2 connection · tear both down.
+
+    readonly defaults True (the poller only reads). The PoI reconcile writer
+    passes readonly=False to UPSERT into compass.poi_credit on the same tunnel."""
     import psycopg2  # local import · pure functions importable without driver
 
     remote_host = cfg.get("host", "localhost")
@@ -331,7 +334,7 @@ def db_connection(cfg: dict, local_port: int = LOCAL_PORT):
             host="127.0.0.1", port=local_port, dbname=dbname,
             user=DB_USER, password=cfg["password"],
             connect_timeout=10, client_encoding="UTF8")
-        conn.set_session(readonly=True, autocommit=True)
+        conn.set_session(readonly=readonly, autocommit=True)
         yield conn
     finally:
         if conn is not None:

--- a/ops/patch_v14_recall_poi_boost.py
+++ b/ops/patch_v14_recall_poi_boost.py
@@ -1,0 +1,91 @@
+"""Inject cloud-side PoI boost into compass_http_v09.py v14_recall (Phase 2).
+Reranks recall hits by the central credit snapshot · env-gated
+(COMPASS_CLOUD_POI_BOOST=1, default OFF) · mtime-cached · never raises (boost is
+an enhancement, recall must never fail). Raw-string helper avoids escaping.
+
+Deploy discipline: download live → patch a copy locally → ast.parse + diff →
+upload → restart → verify (boost off then on). Snapshot delivered to
+/var/lib/compass/poi/poi_credit_snapshot.json by regen_poi_snapshot.sh (cron,
+regenerates from the central poi_credit table = source of truth).
+Usage: python ops/patch_v14_recall_poi_boost.py <target>"""
+import sys
+from pathlib import Path
+
+GUARD = "_v14_poi_boost"
+
+# raw string · written verbatim into the target (NOT exec'd) so backslashes are literal
+BOOST_HELPER = r'''_V14_POI_SNAP = {"data": {}, "mtime": None}
+
+
+def _v14_poi_boost(hits):
+    """Rerank recall hits in place by central PoI credit snapshot. Env-gated
+    (COMPASS_CLOUD_POI_BOOST=1) · mtime-cached · NEVER raises. Boost is an
+    enhancement; recall must never fail because of it. key = project/basename,
+    project normalized to encoded_cwd form (mirrors proof/poi_memory_key)."""
+    if _v14_os.environ.get("COMPASS_CLOUD_POI_BOOST") != "1" or not hits:
+        return hits
+    try:
+        import json as _bj, math as _bm
+        p = _v14_os.environ.get("COMPASS_POI_CREDIT_SNAPSHOT",
+                                "/var/lib/compass/poi/poi_credit_snapshot.json")
+        st = _V14_POI_SNAP
+        if _v14_os.path.exists(p):
+            m = _v14_os.path.getmtime(p)
+            if m != st.get("mtime"):
+                with open(p, encoding="utf-8") as f:
+                    loaded = _bj.load(f)
+                if isinstance(loaded, dict):
+                    st["data"], st["mtime"] = loaded, m
+        snap = st.get("data") or {}
+        if not snap:
+            return hits
+        for h in hits:
+            proj = (h.get("project") or "").strip()
+            if ":" in proj or "\\" in proj:
+                proj = proj.replace(":\\", "--").replace(":/", "--").replace("\\", "-").replace("/", "-")
+            mem = (h.get("path") or h.get("memory") or "").replace("\\", "/").rsplit("/", 1)[-1]
+            cum = snap.get(proj + "/" + mem)
+            if cum is None or not _bm.isfinite(cum):
+                continue
+            boost = max(-0.5, min(1.0, cum * 0.1))
+            new = h.get("score", 0.0) * (1.0 + boost)
+            if _bm.isfinite(new):
+                h["score"] = round(new, 4)
+        hits.sort(key=lambda x: -x.get("score", 0.0))
+    except Exception:
+        pass
+    return hits
+
+
+'''
+
+def apply_patch(target: Path) -> bool:
+    """Idempotently inject the boost helper + call-site. Returns True if patched,
+    False if already patched (guard present). Raises on anchor-not-found."""
+    target = Path(target)
+    src = target.read_text(encoding="utf-8")
+    if GUARD in src:
+        return False
+    # edit 1 · insert helper + global right before the emission helper
+    anchor1 = "def _v14_emit_poi_candidate("
+    i1 = src.find(anchor1)
+    if i1 < 0:
+        raise RuntimeError("anchor not found: emission helper")
+    src = src[:i1] + BOOST_HELPER + src[i1:]
+    # edit 2 · call boost in place right after the recall list is pulled, before emit
+    anchor2 = '        _h = d.get("recall", [])\n'
+    i2 = src.find(anchor2)
+    if i2 < 0:
+        raise RuntimeError("anchor not found: _h = d.get(recall)")
+    ins = anchor2 + "        _v14_poi_boost(_h)  # rerank in place by PoI credit snapshot (env-gated)\n"
+    src = src[:i2] + ins + src[i2 + len(anchor2):]
+    with open(target, "w", encoding="utf-8", newline="\n") as f:
+        f.write(src)
+    assert src.count("def _v14_poi_boost(") == 1
+    assert "_v14_poi_boost(_h)" in src
+    return True
+
+
+if __name__ == "__main__":
+    ok = apply_patch(Path(sys.argv[1]))
+    print("boost injected" if ok else "already patched", "· guard", GUARD)

--- a/ops/patch_v14_recall_poi_candidate.py
+++ b/ops/patch_v14_recall_poi_candidate.py
@@ -14,10 +14,15 @@ GUARD = "_v14_emit_poi_candidate"
 
 # The exact helper deployed into the server. Tested verbatim via exec in
 # tests/test_v14_poi_emission_patch.py (namespace supplies _v14_os, _v14_json).
-EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id, project):
+EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id):
     """Self-contained PoI candidate emission for the v14 recall path.
     One JSONL line per hit -> poi_candidates.jsonl (schema matches
     proof/poi_emitter: ts/kind/actor/project/memory/query_hash/rank/score).
+    `project` is derived PER HIT from each hit's own `project` field — under
+    scope=user one recall returns hits from DIFFERENT projects, and the daemon
+    already tags each hit with its source project. A single query-param project
+    (the requester's context) would mislabel cross-project hits. Mirrors the
+    local emitter (project from the memory file path).
     No proof import (not on this server path) · no self-cite suppression
     (cited memory files are not local to this cloud host). Never raises."""
     if not hits:
@@ -31,11 +36,6 @@ EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id, project):
     _v14_os.makedirs(cache_dir, exist_ok=True)
     sidecar = _v14_os.path.join(cache_dir, "poi_candidates.jsonl")
     actor = agent_id or "unknown"
-    # normalize project to encoded_cwd form · mirrors
-    # proof/poi_memory_key._normalize_project (inline · no proof import here).
-    proj = (project or "").strip()
-    if ":" in proj or "\\\\" in proj:
-        proj = proj.replace(":\\\\", "--").replace(":/", "--").replace("\\\\", "-").replace("/", "-")
     ts = _dt.now(_tz.utc).isoformat(timespec="seconds")
     q_hash = _hl.sha1((query or "").encode("utf-8")).hexdigest()[:16]
     n = 0
@@ -44,6 +44,11 @@ EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id, project):
             mem = h.get("path") or h.get("memory")
             if not mem:
                 continue
+            # normalize each hit's own project to encoded_cwd form · mirrors
+            # proof/poi_memory_key._normalize_project (inline · no proof import).
+            proj = (h.get("project") or "").strip()
+            if ":" in proj or "\\\\" in proj:
+                proj = proj.replace(":\\\\", "--").replace(":/", "--").replace("\\\\", "-").replace("/", "-")
             f.write(_v14_json.dumps({
                 "ts": ts,
                 "kind": "candidate",
@@ -92,7 +97,7 @@ def apply_patch(target: Path) -> bool:
         '    try:\n'
         '        _h = d.get("recall", [])\n'
         '        if _h and _v14_os.environ.get("COMPASS_NO_POI_CANDIDATE") != "1":\n'
-        '            _v14_emit_poi_candidate(_h, q, agent_id, project)\n'
+        '            _v14_emit_poi_candidate(_h, q, agent_id)\n'
         '    except Exception:\n'
         '        pass\n')
     src = src[:sidx] + emit_block + src[sidx:]

--- a/ops/patch_v14_recall_poi_candidate.py
+++ b/ops/patch_v14_recall_poi_candidate.py
@@ -14,10 +14,10 @@ GUARD = "_v14_emit_poi_candidate"
 
 # The exact helper deployed into the server. Tested verbatim via exec in
 # tests/test_v14_poi_emission_patch.py (namespace supplies _v14_os, _v14_json).
-EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id):
+EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id, project):
     """Self-contained PoI candidate emission for the v14 recall path.
     One JSONL line per hit -> poi_candidates.jsonl (schema matches
-    proof/poi_emitter: ts/kind/actor/memory/query_hash/rank/score).
+    proof/poi_emitter: ts/kind/actor/project/memory/query_hash/rank/score).
     No proof import (not on this server path) · no self-cite suppression
     (cited memory files are not local to this cloud host). Never raises."""
     if not hits:
@@ -31,6 +31,11 @@ EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id):
     _v14_os.makedirs(cache_dir, exist_ok=True)
     sidecar = _v14_os.path.join(cache_dir, "poi_candidates.jsonl")
     actor = agent_id or "unknown"
+    # normalize project to encoded_cwd form · mirrors
+    # proof/poi_memory_key._normalize_project (inline · no proof import here).
+    proj = (project or "").strip()
+    if ":" in proj or "\\\\" in proj:
+        proj = proj.replace(":\\\\", "--").replace(":/", "--").replace("\\\\", "-").replace("/", "-")
     ts = _dt.now(_tz.utc).isoformat(timespec="seconds")
     q_hash = _hl.sha1((query or "").encode("utf-8")).hexdigest()[:16]
     n = 0
@@ -43,6 +48,7 @@ EMIT_HELPER = '''def _v14_emit_poi_candidate(hits, query, agent_id):
                 "ts": ts,
                 "kind": "candidate",
                 "actor": actor,
+                "project": proj,
                 "memory": mem,
                 "query_hash": q_hash,
                 "rank": rank,
@@ -86,7 +92,7 @@ def apply_patch(target: Path) -> bool:
         '    try:\n'
         '        _h = d.get("recall", [])\n'
         '        if _h and _v14_os.environ.get("COMPASS_NO_POI_CANDIDATE") != "1":\n'
-        '            _v14_emit_poi_candidate(_h, q, agent_id)\n'
+        '            _v14_emit_poi_candidate(_h, q, agent_id, project)\n'
         '    except Exception:\n'
         '        pass\n')
     src = src[:sidx] + emit_block + src[sidx:]

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -111,7 +111,14 @@ def main() -> int:
     n_local = 0
     n_outcomes = 0
     try:
-        with _poller.db_connection(cfg) as conn:
+        # readonly=dry_run · a real run needs write (UPSERT poi_credit); a
+        # dry-run stays read-only so it physically cannot mutate the cloud.
+        with _poller.db_connection(cfg, readonly=dry_run) as conn:
+            # compass.poi_credit lives in the compass schema · compass_sub's default
+            # search_path excludes it. Set it so the store's unqualified `poi_credit`
+            # resolves (keeps the store SQL backend-agnostic for the sqlite tests).
+            # public stays on path so agent_tool_calls still resolves.
+            conn.cursor().execute("SET search_path TO compass, public")
             # Platform outcomes (agent_tool_calls) · credits platform agents.
             outcomes: list = list(_fetch_outcomes_for(conn, actors, since, WINDOW_S))
 

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -31,13 +31,29 @@ _spec.loader.exec_module(_poller)
 
 sys.path.insert(0, str(_HERE.parent))
 from proof import poi_reconciler as R  # noqa: E402
+from proof import poi_credit_store as CS  # noqa: E402
 
 CANDIDATE_DIR = Path(os.environ.get(
     "COMPASS_POI_CACHE_DIR",
     str(Path.home() / ".claude" / "plugins" / "nautilus-compass" / ".cache")))
 WINDOW_S = int(os.environ.get("COMPASS_POI_RECONCILE_WINDOW_S", str(R.DEFAULT_WINDOW_S)))
-# memory_root: where cited memory files live (to update their frontmatter)
+# memory_root: where cited memory files live (legacy frontmatter path · unused by main)
 MEMORY_ROOT = os.environ.get("COMPASS_POI_MEMORY_ROOT", "")
+# atomic snapshot of the central poi_credit table · the daemon reads this for boost
+SNAPSHOT_PATH = Path(os.environ.get(
+    "COMPASS_POI_CREDIT_SNAPSHOT", str(CANDIDATE_DIR / "poi_credit_cache.json")))
+
+
+def settle_and_snapshot(conn, pending, outcomes, settled_keys, *, snapshot_path,
+                        window_s=WINDOW_S, placeholder="%s"):
+    """Settle pending candidates into the central poi_credit table, then export
+    the full credit table as an atomic snapshot the daemon reads for boost.
+    Returns the reconcile_central result dict."""
+    res = R.reconcile_central(pending, outcomes, conn=conn, settled_keys=settled_keys,
+                              window_seconds=window_s, placeholder=placeholder)
+    credits = CS.fetch_all_credits(conn)
+    CS.write_snapshot_atomic(snapshot_path, credits)
+    return res
 
 
 def _fetch_outcomes_for(conn, actors: list, since_iso: str, window_s: int) -> list:
@@ -75,41 +91,54 @@ def main() -> int:
     since = min(str(c.get("ts", "")) for c in pending)
     memory_root = Path(MEMORY_ROOT) if MEMORY_ROOT else None
 
-    outcomes: list = []
-
-    # Platform outcomes (agent_tool_calls) · credits platform agents · graceful
-    # skip when the DB secret is not provisioned (path B works without it).
+    # Phase 1 central credit REQUIRES the cloud DB · reconcile_central writes to
+    # the poi_credit table (not frontmatter). No secret → no settle, honest skip.
     try:
         cfg = _poller.parse_secret(_poller.SECRET_FILE)
-        with _poller.db_connection(cfg) as conn:
-            outcomes += _fetch_outcomes_for(conn, actors, since, WINDOW_S)
     except (FileNotFoundError, ValueError) as e:
-        sys.stderr.write(f"platform outcomes skipped · secret unavailable · {e}\n")
-    except Exception as e:
-        sys.stderr.write(f"platform outcome fetch failed · {type(e).__name__}: {str(e)[:200]}\n")
-
-    # Path B · local outcomes from the user's own session_*.md drift signal ·
-    # lets local (anon/unknown) recalls self-settle without any platform agent.
-    n_local = 0
-    if memory_root and os.environ.get("COMPASS_POI_LOCAL_OUTCOMES", "1") != "0":
-        try:
-            from proof import local_outcomes as _LO
-            for actor in actors:
-                lo = _LO.local_outcomes(memory_root, actor, since_iso=since)
-                outcomes += lo
-                n_local += len(lo)
-        except Exception as e:
-            sys.stderr.write(f"local outcomes skipped · {type(e).__name__}: {str(e)[:160]}\n")
-
-    if not outcomes:
-        print("no outcomes (platform + local) · nothing to settle yet")
+        sys.stderr.write(
+            f"reconcile skipped · DB secret unavailable · central credit needs the "
+            f"cloud DB · {e}\n")
         return 0
 
-    work_keys = set() if dry_run else settled_keys
+    res = None
+    n_local = 0
+    n_outcomes = 0
     try:
-        res = R.reconcile(pending, outcomes, settled_keys=work_keys,
-                          window_seconds=WINDOW_S, memory_root=memory_root,
-                          cache_dir=(CANDIDATE_DIR if not dry_run else Path(os.devnull).parent))
+        with _poller.db_connection(cfg) as conn:
+            # Platform outcomes (agent_tool_calls) · credits platform agents.
+            outcomes: list = list(_fetch_outcomes_for(conn, actors, since, WINDOW_S))
+
+            # Path B · local outcomes from the user's own session_*.md drift
+            # signal · lets local (anon/unknown) recalls self-settle. Gathered
+            # BEFORE the settle so they credit via the same conn.
+            if memory_root and os.environ.get("COMPASS_POI_LOCAL_OUTCOMES", "1") != "0":
+                try:
+                    from proof import local_outcomes as _LO
+                    for actor in actors:
+                        lo = _LO.local_outcomes(memory_root, actor, since_iso=since)
+                        outcomes += lo
+                        n_local += len(lo)
+                except Exception as e:
+                    sys.stderr.write(
+                        f"local outcomes skipped · {type(e).__name__}: {str(e)[:160]}\n")
+
+            n_outcomes = len(outcomes)
+            if not outcomes:
+                print("no outcomes (platform + local) · nothing to settle yet")
+                return 0
+
+            work_keys = set(settled_keys) if dry_run else settled_keys
+            snap_path = (SNAPSHOT_PATH.with_suffix(".dryrun.tmp")
+                         if dry_run else SNAPSHOT_PATH)
+            res = settle_and_snapshot(conn, pending, outcomes, work_keys,
+                                      snapshot_path=snap_path, window_s=WINDOW_S,
+                                      placeholder="%s")
+    except (FileNotFoundError, ValueError) as e:
+        sys.stderr.write(
+            f"reconcile skipped · DB connect failed · central credit needs the "
+            f"cloud DB · {e}\n")
+        return 0
     except Exception as e:
         sys.stderr.write(f"reconcile failed · {type(e).__name__}: {str(e)[:200]}\n")
         return 1
@@ -119,8 +148,9 @@ def main() -> int:
 
     print(f"{datetime.now(timezone.utc).isoformat(timespec='seconds')} · "
           f"candidates={len(candidates)} pending={len(pending)} "
-          f"actors={len(actors)} outcomes={len(outcomes)} (local={n_local}) "
-          f"settled={res['settled']} no_match={res['skipped_no_match']}"
+          f"actors={len(actors)} outcomes={n_outcomes} (local={n_local}) "
+          f"settled={res['settled']} no_match={res['skipped_no_match']} "
+          f"selfcite={res['skipped_selfcite']}"
           + (" · DRY-RUN" if dry_run else ""))
     return 0
 

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -88,7 +88,7 @@ def main() -> int:
         return 0
 
     settled_keys = R.load_settled(settled_path)
-    pending = [c for c in candidates if R.candidate_key(c) not in settled_keys]
+    pending = [c for c in candidates if R.central_candidate_key(c) not in settled_keys]
     if not pending:
         print(f"all {len(candidates)} candidates already settled")
         return 0

--- a/ops/poi_reconcile_cron.py
+++ b/ops/poi_reconcile_cron.py
@@ -45,12 +45,18 @@ SNAPSHOT_PATH = Path(os.environ.get(
 
 
 def settle_and_snapshot(conn, pending, outcomes, settled_keys, *, snapshot_path,
-                        window_s=WINDOW_S, placeholder="%s"):
+                        window_s=WINDOW_S, placeholder="%s", dry_run=False):
     """Settle pending candidates into the central poi_credit table, then export
     the full credit table as an atomic snapshot the daemon reads for boost.
-    Returns the reconcile_central result dict."""
+    Returns the reconcile_central result dict.
+
+    dry_run=True · reconcile counts what WOULD settle but writes nothing to the DB;
+    the snapshot write is skipped entirely (truly read-only)."""
     res = R.reconcile_central(pending, outcomes, conn=conn, settled_keys=settled_keys,
-                              window_seconds=window_s, placeholder=placeholder)
+                              window_seconds=window_s, placeholder=placeholder,
+                              dry_run=dry_run)
+    if dry_run:
+        return res
     credits = CS.fetch_all_credits(conn)
     CS.write_snapshot_atomic(snapshot_path, credits)
     return res
@@ -129,11 +135,9 @@ def main() -> int:
                 return 0
 
             work_keys = set(settled_keys) if dry_run else settled_keys
-            snap_path = (SNAPSHOT_PATH.with_suffix(".dryrun.tmp")
-                         if dry_run else SNAPSHOT_PATH)
             res = settle_and_snapshot(conn, pending, outcomes, work_keys,
-                                      snapshot_path=snap_path, window_s=WINDOW_S,
-                                      placeholder="%s")
+                                      snapshot_path=SNAPSHOT_PATH, window_s=WINDOW_S,
+                                      placeholder="%s", dry_run=dry_run)
     except (FileNotFoundError, ValueError) as e:
         sys.stderr.write(
             f"reconcile skipped · DB connect failed · central credit needs the "

--- a/ops/regen_poi_snapshot.sh
+++ b/ops/regen_poi_snapshot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Regenerate the PoI credit snapshot from the central table (source of truth).
+# Atomic write (tmp+mv) · the cloud v14 boost (_v14_poi_boost) mtime-reloads it.
+# Deployed on cloud at /home/ubuntu/compass/regen_poi_snapshot.sh · cron every 10min:
+#   */10 * * * * /home/ubuntu/compass/regen_poi_snapshot.sh >/dev/null 2>&1
+# Snapshot path = /var/lib/compass/poi (systemd ReadWritePaths whitelist · NOT
+# /home/ubuntu/compass which is read-only under ProtectHome).
+set -e
+OUT=/var/lib/compass/poi/poi_credit_snapshot.json
+sudo -u postgres psql -tAc \
+  "SELECT coalesce(json_object_agg(memory_key, cumulative_impact)::text,'{}') FROM compass.poi_credit" \
+  nautilus_production > ${OUT}.tmp
+mv ${OUT}.tmp $OUT

--- a/proof/poi_credit_store.py
+++ b/proof/poi_credit_store.py
@@ -1,0 +1,54 @@
+"""Central PoI credit table I/O + atomic snapshot. Replaces frontmatter as the
+credit source of truth. Reference: design §4.1/§4.3. NO LLM."""
+from __future__ import annotations
+import json, os, tempfile
+from pathlib import Path
+from typing import Dict
+
+UPSERT_SQL = (
+    "INSERT INTO poi_credit (memory_key, cumulative_impact, event_count, last_impact_at) "
+    "VALUES ({p}, {p}, 1, {p}) "
+    "ON CONFLICT (memory_key) DO UPDATE SET "
+    "cumulative_impact = poi_credit.cumulative_impact + EXCLUDED.cumulative_impact, "
+    "event_count = poi_credit.event_count + 1, "
+    "last_impact_at = EXCLUDED.last_impact_at"
+)
+
+
+def upsert_credit(conn, memory_key: str, delta: float, now_iso: str, placeholder: str = "%s") -> None:
+    """Accumulate delta onto memory_key. placeholder='%s' for psycopg2, '?' for sqlite."""
+    sql = UPSERT_SQL.format(p=placeholder)
+    cur = conn.cursor()
+    cur.execute(sql, (memory_key, float(delta), now_iso))
+    conn.commit()
+
+
+def fetch_all_credits(conn) -> Dict[str, float]:
+    cur = conn.cursor()
+    cur.execute("SELECT memory_key, cumulative_impact FROM poi_credit")
+    return {k: float(v) for k, v in cur.fetchall()}
+
+
+def write_snapshot_atomic(path, credit: Dict[str, float]) -> None:
+    """tmp -> fsync -> os.replace · daemon never reads a half-written file."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(credit, f, ensure_ascii=False)
+            f.flush(); os.fsync(f.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def load_snapshot(path) -> Dict[str, float]:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}

--- a/proof/poi_emitter.py
+++ b/proof/poi_emitter.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from .poi_schema import ProofOfImpact
 from .l1_grouper_compat import parse_session_frontmatter_safe
+from .poi_memory_key import memory_key_from_path
 
 BASE_NAU_PER_ACTION = float(os.environ.get("COMPASS_POI_BASE_NAU", "1.0"))
 SUPPRESS_SELFCITE = os.environ.get("COMPASS_POI_SUPPRESS_SELFCITE", "true").lower() == "true"
@@ -185,16 +186,19 @@ def emit_poi_candidate(top, query: str, agent_id: Optional[str] = None,
                 continue
             # Self-cite suppression · mirrors emit_nau_records · skip when the
             # memory was created by the same agent making the recall.
-            if SUPPRESS_SELFCITE and agent_id:
-                front = parse_session_frontmatter_safe(path)
-                creator = front.get("agent_type", "") or front.get("agent_id", "")
-                if creator == agent_id:
-                    continue
+            front = parse_session_frontmatter_safe(path)
+            creator = front.get("agent_type", "") or front.get("agent_id", "")
+            if SUPPRESS_SELFCITE and agent_id and creator == agent_id:
+                continue
+            mk = memory_key_from_path(path)
+            project = mk.split("/", 1)[0] if mk else os.environ.get("COMPASS_PROJECT_NS", "")
             f.write(json.dumps({
                 "ts": ts,
                 "kind": "candidate",
                 "actor": actor,
+                "project": project,
                 "memory": path.name,
+                "creator": creator,
                 "query_hash": q_hash,
                 "rank": rank,
                 "score": round(float(score), 4),

--- a/proof/poi_memory_key.py
+++ b/proof/poi_memory_key.py
@@ -24,11 +24,19 @@ def derive_memory_key(project: str, filename: str) -> str:
 
 
 def memory_key_from_path(path) -> Optional[str]:
-    """Derive key from a memory file path .../projects/<project>/memory/<file>.
-    Returns None if path is just a filename (project undeterminable)."""
-    s = str(path).replace("\\", "/")
-    parts = s.split("/")
+    """Derive key from a memory file path .../<project>/memory/<file>.
+    Anchors on the literal 'memory' directory segment: project is the segment
+    immediately before it, filename is the last segment. Returns None when the
+    layout doesn't match (bare filename, no 'memory' dir, nothing before it, or
+    'memory' is the last segment) so callers fall back to frontmatter / env NS —
+    never silently mislabel an unrelated path segment as the project."""
+    parts = [p for p in str(path).replace("\\", "/").split("/") if p]
     if len(parts) < 3:
         return None  # filename only or too shallow
-    # <project>/memory/<file>  → project = parts[-3]
-    return derive_memory_key(parts[-3], parts[-1])
+    try:
+        midx = len(parts) - 1 - parts[::-1].index("memory")  # last 'memory' segment
+    except ValueError:
+        return None  # no 'memory' dir → project undeterminable
+    if midx == 0 or midx == len(parts) - 1:
+        return None  # nothing before 'memory' (no project) or it IS the last part
+    return derive_memory_key(parts[midx - 1], parts[-1])

--- a/proof/poi_memory_key.py
+++ b/proof/poi_memory_key.py
@@ -1,0 +1,34 @@
+"""Single source of truth for PoI memory_key = project/filename.
+Used by emission (local + cloud inline copy), reconcile, boost, migration.
+Pure · no I/O on the derive path. Reference: docs/plans/2026-06-03-poi-central-ledger-design.md §5.
+"""
+from __future__ import annotations
+from typing import Optional
+
+
+def _normalize_project(project: str) -> str:
+    """Match recall.py encoded_cwd form: C:\\Users\\chunx -> C--Users-chunx."""
+    p = (project or "").strip()
+    if ":" in p or "\\" in p:
+        p = p.replace(":\\", "--").replace(":/", "--").replace("\\", "-").replace("/", "-")
+    return p
+
+
+def _basename(filename: str) -> str:
+    name = (filename or "").strip().replace("\\", "/")
+    return name.rsplit("/", 1)[-1]
+
+
+def derive_memory_key(project: str, filename: str) -> str:
+    return f"{_normalize_project(project)}/{_basename(filename)}"
+
+
+def memory_key_from_path(path) -> Optional[str]:
+    """Derive key from a memory file path .../projects/<project>/memory/<file>.
+    Returns None if path is just a filename (project undeterminable)."""
+    s = str(path).replace("\\", "/")
+    parts = s.split("/")
+    if len(parts) < 3:
+        return None  # filename only or too shallow
+    # <project>/memory/<file>  → project = parts[-3]
+    return derive_memory_key(parts[-3], parts[-1])

--- a/proof/poi_reconciler.py
+++ b/proof/poi_reconciler.py
@@ -69,6 +69,14 @@ def candidate_key(cand: dict) -> str:
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:20]
 
 
+def central_candidate_key(cand: dict) -> str:
+    """The idempotency key reconcile_central settles on · uses the project-derived
+    memory_key so the same memory under different projects doesn't collide and the
+    cron pre-filter matches what reconcile_central persists."""
+    mk = derive_memory_key(cand.get("project", ""), cand.get("memory", ""))
+    return candidate_key({**cand, "memory": mk})
+
+
 def match_outcome(cand: dict, outcomes: list, window_seconds: int = DEFAULT_WINDOW_S) -> Optional[dict]:
     """Earliest outcome by the same actor strictly after the candidate, in window."""
     c_ts = _parse_ts(cand.get("ts"))
@@ -189,8 +197,8 @@ def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
         settled_keys = set()
     settled = skipped_no_match = skipped_already = skipped_selfcite = 0
     for cand in candidates:
-        mk = derive_memory_key(cand.get("project", ""), cand.get("memory", ""))
-        key = candidate_key({**cand, "memory": mk})  # key includes project
+        mk = derive_memory_key(cand.get("project", ""), cand.get("memory", ""))  # for upsert_credit
+        key = central_candidate_key(cand)  # single definition of the central settled-key
         if key in settled_keys:
             skipped_already += 1
             continue

--- a/proof/poi_reconciler.py
+++ b/proof/poi_reconciler.py
@@ -26,6 +26,8 @@ from typing import Optional
 from .poi_schema import ProofOfImpact
 from .poi_calculator import compute_with_drift
 from .poi_emitter import emit_full
+from .poi_memory_key import derive_memory_key
+from .poi_credit_store import upsert_credit
 
 CANDIDATE_SIDECAR = "poi_candidates.jsonl"
 SETTLED_STATE = "poi_settled.json"
@@ -172,3 +174,38 @@ def reconcile(candidates: list, outcomes: list, *, settled_keys: Optional[set] =
 
     return {"settled": settled, "skipped_no_match": skipped_no_match,
             "skipped_already": skipped_already}
+
+
+def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
+                      window_seconds=DEFAULT_WINDOW_S, placeholder="%s"):
+    """Settle candidates into the central poi_credit table (not frontmatter).
+    No local-file requirement (M1 relaxed) · DB-side self-cite filter via creator.
+    Mutates settled_keys in place (idempotent re-run)."""
+    if settled_keys is None:
+        settled_keys = set()
+    settled = skipped_no_match = skipped_already = skipped_selfcite = 0
+    for cand in candidates:
+        mk = derive_memory_key(cand.get("project", ""), cand.get("memory", ""))
+        key = candidate_key({**cand, "memory": mk})  # key includes project
+        if key in settled_keys:
+            skipped_already += 1
+            continue
+        if cand.get("creator") and cand.get("creator") == cand.get("actor"):
+            skipped_selfcite += 1
+            continue
+        outcome = match_outcome(cand, outcomes, window_seconds=window_seconds)
+        if outcome is None:
+            skipped_no_match += 1
+            continue
+        poi = ProofOfImpact(
+            action_id=f"recon-{key}", agent_id=cand["actor"], cited_memory_paths=[cand["memory"]],
+            action_outcome=outcome_to_action_outcome(outcome),
+            timestamp_action=str(cand.get("ts", "")), timestamp_outcome=str(outcome.get("ts", "")),
+            notes=f"central reconcile {cand['actor']}")
+        compute_with_drift(poi, memory_root=None)
+        now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        upsert_credit(conn, mk, poi.impact_score, now_iso, placeholder=placeholder)
+        settled_keys.add(key)
+        settled += 1
+    return {"settled": settled, "skipped_no_match": skipped_no_match,
+            "skipped_already": skipped_already, "skipped_selfcite": skipped_selfcite}

--- a/proof/poi_reconciler.py
+++ b/proof/poi_reconciler.py
@@ -195,8 +195,14 @@ def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
     copy in dry-run) so the report shows what WOULD have settled. Truly read-only."""
     if settled_keys is None:
         settled_keys = set()
-    settled = skipped_no_match = skipped_already = skipped_selfcite = 0
+    settled = skipped_no_match = skipped_already = skipped_selfcite = skipped_no_project = 0
     for cand in candidates:
+        # Defensive · a candidate without project derives a degenerate "/file" key
+        # (boost computes "project/file" from the path, so it would never match).
+        # Skip · old pre-project candidates must not pollute the central table.
+        if not (cand.get("project") or "").strip():
+            skipped_no_project += 1
+            continue
         mk = derive_memory_key(cand.get("project", ""), cand.get("memory", ""))  # for upsert_credit
         key = central_candidate_key(cand)  # single definition of the central settled-key
         if key in settled_keys:
@@ -221,4 +227,5 @@ def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
         settled_keys.add(key)
         settled += 1
     return {"settled": settled, "skipped_no_match": skipped_no_match,
-            "skipped_already": skipped_already, "skipped_selfcite": skipped_selfcite}
+            "skipped_already": skipped_already, "skipped_selfcite": skipped_selfcite,
+            "skipped_no_project": skipped_no_project}

--- a/proof/poi_reconciler.py
+++ b/proof/poi_reconciler.py
@@ -177,10 +177,14 @@ def reconcile(candidates: list, outcomes: list, *, settled_keys: Optional[set] =
 
 
 def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
-                      window_seconds=DEFAULT_WINDOW_S, placeholder="%s"):
+                      window_seconds=DEFAULT_WINDOW_S, placeholder="%s", dry_run=False):
     """Settle candidates into the central poi_credit table (not frontmatter).
     No local-file requirement (M1 relaxed) · DB-side self-cite filter via creator.
-    Mutates settled_keys in place (idempotent re-run)."""
+    Mutates settled_keys in place (idempotent re-run).
+
+    dry_run=True · do everything EXCEPT the DB write: skip upsert_credit, but still
+    count it as settled and add the key to settled_keys (caller passes a throwaway
+    copy in dry-run) so the report shows what WOULD have settled. Truly read-only."""
     if settled_keys is None:
         settled_keys = set()
     settled = skipped_no_match = skipped_already = skipped_selfcite = 0
@@ -203,8 +207,9 @@ def reconcile_central(candidates, outcomes, *, conn, settled_keys=None,
             timestamp_action=str(cand.get("ts", "")), timestamp_outcome=str(outcome.get("ts", "")),
             notes=f"central reconcile {cand['actor']}")
         compute_with_drift(poi, memory_root=None)
-        now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        upsert_credit(conn, mk, poi.impact_score, now_iso, placeholder=placeholder)
+        if not dry_run:
+            now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            upsert_credit(conn, mk, poi.impact_score, now_iso, placeholder=placeholder)
         settled_keys.add(key)
         settled += 1
     return {"settled": settled, "skipped_no_match": skipped_no_match,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ extend-exclude = [
     "scripts/_archive",
     ".cache",
     "__pycache__",
+    "*.ipynb",  # bench/colab notebooks are not linted as source
 ]
 
 [tool.ruff.lint]

--- a/recall.py
+++ b/recall.py
@@ -1005,9 +1005,9 @@ def render_v02_vector_mode(entries: list, query: str, cache: dict) -> None:
     # equivalent to v0.8). Set COMPASS_NO_POI_BOOST=1 to opt out.
     if os.environ.get("COMPASS_NO_POI_BOOST") != "1":
         try:
-            from recall_pkg.poi_weighting import boost_top_k
-            _before_top = top
-            top = boost_top_k(top)
+            from recall_pkg.poi_weighting import boost_top_k_with_snapshot
+            from recall_pkg.poi_snapshot_cache import get_credit_snapshot
+            top = boost_top_k_with_snapshot(top, get_credit_snapshot())
             # Truncate back to TOP_K after potential re-rank
             top = top[:TOP_K]
         except Exception as _e:

--- a/recall_pkg/poi_snapshot_cache.py
+++ b/recall_pkg/poi_snapshot_cache.py
@@ -1,0 +1,71 @@
+"""Lazy mtime-cached PoI credit snapshot for the long-running daemon boost path.
+
+Reloads only when the snapshot file's mtime changes · keeps last-good dict if a
+reload fails (corrupt/half-written) or the file disappears · never raises. The
+boost is an enhancement, not a dependency, so any error degrades gracefully to
+the last-good (or empty) dict. Reference: design §4.3/§8.
+"""
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Dict
+
+try:
+    from ..proof.poi_credit_store import load_snapshot
+except (ImportError, ValueError):
+    from proof.poi_credit_store import load_snapshot  # type: ignore
+
+_CACHE: Dict[str, float] = {}
+_MTIME: float = -1.0
+_LOADED_PATH: str = ""
+
+
+def _snapshot_path() -> Path:
+    env = os.environ.get("COMPASS_POI_CREDIT_SNAPSHOT")
+    if env:
+        return Path(env)
+    base = os.environ.get(
+        "COMPASS_POI_CACHE_DIR",
+        str(Path.home() / ".claude" / "plugins" / "nautilus-compass" / ".cache"),
+    )
+    return Path(base) / "poi_credit_cache.json"
+
+
+def reset_cache() -> None:
+    """Test helper · drop the in-memory cache so the next get reloads."""
+    global _CACHE, _MTIME, _LOADED_PATH
+    _CACHE, _MTIME, _LOADED_PATH = {}, -1.0, ""
+
+
+def get_credit_snapshot() -> Dict[str, float]:
+    """Return the credit dict · reload from disk only on mtime/path change.
+
+    On any error or corrupt reload, keep the last-good dict. When the configured
+    path changes (e.g. tests swapping snapshots), the cache resets for the new
+    path before attempting a load.
+    """
+    global _CACHE, _MTIME, _LOADED_PATH
+    p = _snapshot_path()
+    path_str = str(p)
+    try:
+        # Path changed → forget the previous snapshot's cache.
+        if path_str != _LOADED_PATH:
+            _CACHE, _MTIME, _LOADED_PATH = {}, -1.0, path_str
+
+        if not p.exists():
+            return _CACHE
+
+        mtime = p.stat().st_mtime
+        if mtime == _MTIME:
+            return _CACHE  # unchanged since last load
+
+        loaded = load_snapshot(p)
+        _MTIME = mtime
+        # load_snapshot returns {} on corrupt/unreadable. Only adopt non-empty
+        # data so a corrupt reload keeps the last-good dict. An intentionally
+        # empty snapshot stays empty because _CACHE is already {} in that case.
+        if loaded:
+            _CACHE = loaded
+        return _CACHE
+    except Exception:
+        return _CACHE

--- a/recall_pkg/poi_weighting.py
+++ b/recall_pkg/poi_weighting.py
@@ -10,10 +10,17 @@ Reference: paper/SPEC_PROOF_OF_IMPACT.md section 7.
 """
 from __future__ import annotations
 
+import math
+
 try:
     from ..proof.l1_grouper_compat import parse_session_frontmatter_safe
 except (ImportError, ValueError):
     from proof.l1_grouper_compat import parse_session_frontmatter_safe  # type: ignore
+
+try:
+    from ..proof.poi_memory_key import memory_key_from_path
+except (ImportError, ValueError):
+    from proof.poi_memory_key import memory_key_from_path  # type: ignore
 
 BOOST_FACTOR_DEFAULT = 0.1
 BOOST_CAP = 1.0  # max +1.0 → result = base × 2.0
@@ -65,6 +72,37 @@ def boost_top_k(top_entries: list, boost_factor: float = BOOST_FACTOR_DEFAULT) -
             continue
         front = parse_session_frontmatter_safe(path)
         new_score = apply_poi_boost(score, front, boost_factor=boost_factor)
+        boosted.append((new_score, entry))
+    boosted.sort(key=lambda x: x[0], reverse=True)
+    return boosted
+
+
+def apply_poi_boost_value(cosine_score: float, cumulative: float,
+                          boost_factor: float = BOOST_FACTOR_DEFAULT) -> float:
+    """Boost from a raw cumulative value (snapshot path). NaN/inf-safe."""
+    if not math.isfinite(cumulative):
+        return cosine_score
+    boost = max(BOOST_FLOOR, min(BOOST_CAP, cumulative * boost_factor))
+    out = cosine_score * (1.0 + boost)
+    return out if math.isfinite(out) else cosine_score
+
+
+def boost_top_k_with_snapshot(top_entries: list, snapshot: dict,
+                              boost_factor: float = BOOST_FACTOR_DEFAULT) -> list:
+    """Re-rank using central-credit snapshot dict (memory_key -> cumulative).
+    Miss → fall back to frontmatter read (transition). Never raises."""
+    boosted = []
+    for score, entry in top_entries:
+        if not isinstance(entry, dict):
+            boosted.append((score, entry))
+            continue
+        path = entry.get("fullpath") or entry.get("path") or ""
+        mk = memory_key_from_path(path) if path else None
+        if mk is not None and mk in snapshot:
+            new_score = apply_poi_boost_value(score, snapshot[mk], boost_factor)
+        else:
+            front = parse_session_frontmatter_safe(path) if path else {}
+            new_score = apply_poi_boost(score, front, boost_factor=boost_factor)
         boosted.append((new_score, entry))
     boosted.sort(key=lambda x: x[0], reverse=True)
     return boosted

--- a/sql/004_poi_credit.sql
+++ b/sql/004_poi_credit.sql
@@ -15,4 +15,7 @@ CREATE TABLE IF NOT EXISTS compass.poi_credit (
 
 -- Phase 1: reuse the existing writable account. Phase 2 introduces a dedicated
 -- poi_writer role and tightens this grant. TODO(Phase 2): move write to poi_writer.
+-- compass_sub needs USAGE on the schema to reference objects in it · table-level
+-- grants alone are insufficient (compass_sub did not previously touch compass.*).
+GRANT USAGE ON SCHEMA compass TO compass_sub;
 GRANT SELECT, INSERT, UPDATE ON compass.poi_credit TO compass_sub;

--- a/sql/004_poi_credit.sql
+++ b/sql/004_poi_credit.sql
@@ -1,0 +1,18 @@
+-- 004 · PoI central credit table (Option C · MVP single-table)
+-- Apply on cloud (nautilus_production) AFTER 003.
+-- Reference: docs/plans/2026-06-03-poi-central-ledger-design.md §4.1
+--
+-- Phase 1: credit source of truth migrates from memory-file frontmatter to this
+-- table. memory_key (the memory filename) is the cross-agent join key, so file
+-- location no longer pins credit to one host.
+
+CREATE TABLE IF NOT EXISTS compass.poi_credit (
+    memory_key        text             PRIMARY KEY,
+    cumulative_impact double precision NOT NULL DEFAULT 0,
+    event_count       int              NOT NULL DEFAULT 0,
+    last_impact_at    timestamptz
+);
+
+-- Phase 1: reuse the existing writable account. Phase 2 introduces a dedicated
+-- poi_writer role and tightens this grant. TODO(Phase 2): move write to poi_writer.
+GRANT SELECT, INSERT, UPDATE ON compass.poi_credit TO compass_sub;

--- a/tests/drift/test_firing.py
+++ b/tests/drift/test_firing.py
@@ -7,7 +7,6 @@ Verifies the new firing logic raises specificity over the old OR-vote:
   - legacy=True kwarg restores OR-vote semantics
 """
 import sys
-import os
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/tests/scripts/test_tier_promotion_driver.py
+++ b/tests/scripts/test_tier_promotion_driver.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 
 # --- Helpers ---

--- a/tests/test_act_on_log.py
+++ b/tests/test_act_on_log.py
@@ -26,11 +26,9 @@ from __future__ import annotations
 
 import json
 import sys
-import time
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
-import pytest
 
 # Ensure repo root on sys.path
 _REPO_ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_contract_consumer.py
+++ b/tests/test_contract_consumer.py
@@ -26,7 +26,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 # Ensure repo root on sys.path so `import contract` resolves the project module
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -35,7 +34,6 @@ if str(_REPO_ROOT) not in sys.path:
 
 import contract as contract_mod  # noqa: E402
 from contract import (  # noqa: E402
-    Contract,
     parse_contracts_from_frontmatter,
     scan_sessions_for_contracts,
 )

--- a/tests/test_cross_agent_poller.py
+++ b/tests/test_cross_agent_poller.py
@@ -6,7 +6,6 @@ separately and kept thin / not unit-tested here.
 """
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from pathlib import Path
 

--- a/tests/test_poi_candidate_project.py
+++ b/tests/test_poi_candidate_project.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 from proof.poi_emitter import emit_poi_candidate
 
 def test_candidate_carries_project_and_creator(tmp_path):

--- a/tests/test_poi_candidate_project.py
+++ b/tests/test_poi_candidate_project.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+from proof.poi_emitter import emit_poi_candidate
+
+def test_candidate_carries_project_and_creator(tmp_path):
+    mem = tmp_path / "projects" / "C--Users-chunx" / "memory" / "m.md"
+    mem.parent.mkdir(parents=True)
+    mem.write_text("---\nagent_type: other-agent\n---\nbody", encoding="utf-8")
+    top = [(0.9, {"fullpath": str(mem), "path": "m.md"})]
+    n = emit_poi_candidate(top, query="q", agent_id="me", cache_dir=tmp_path)
+    line = json.loads((tmp_path / "poi_candidates.jsonl").read_text().splitlines()[0])
+    assert n == 1
+    assert line["project"] == "C--Users-chunx"
+    assert line["memory"] == "m.md"
+    assert line["creator"] == "other-agent"

--- a/tests/test_poi_credit_store.py
+++ b/tests/test_poi_credit_store.py
@@ -1,5 +1,4 @@
-import json, sqlite3
-from pathlib import Path
+import sqlite3
 from proof.poi_credit_store import (
     upsert_credit, fetch_all_credits, write_snapshot_atomic, load_snapshot,
 )

--- a/tests/test_poi_credit_store.py
+++ b/tests/test_poi_credit_store.py
@@ -1,0 +1,43 @@
+import json, sqlite3
+from pathlib import Path
+from proof.poi_credit_store import (
+    upsert_credit, fetch_all_credits, write_snapshot_atomic, load_snapshot,
+)
+
+CREATE_SQLITE = (
+    "CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, "
+    "cumulative_impact REAL NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0, "
+    "last_impact_at TEXT)"
+)
+
+def _conn():
+    c = sqlite3.connect(":memory:")
+    c.execute(CREATE_SQLITE)
+    return c
+
+def test_upsert_accumulates():
+    c = _conn()
+    upsert_credit(c, "proj/a.md", 0.5, "2026-06-03T00:00:00+00:00", placeholder="?")
+    upsert_credit(c, "proj/a.md", 0.3, "2026-06-03T01:00:00+00:00", placeholder="?")
+    row = c.execute("SELECT cumulative_impact, event_count FROM poi_credit WHERE memory_key='proj/a.md'").fetchone()
+    assert round(row[0], 4) == 0.8 and row[1] == 2
+
+def test_fetch_all_credits_dict():
+    c = _conn()
+    upsert_credit(c, "proj/a.md", 0.5, "t", placeholder="?")
+    upsert_credit(c, "proj/b.md", -0.2, "t", placeholder="?")
+    d = fetch_all_credits(c)
+    assert d == {"proj/a.md": 0.5, "proj/b.md": -0.2}
+
+def test_snapshot_atomic_roundtrip(tmp_path):
+    snap = tmp_path / "poi_credit_cache.json"
+    write_snapshot_atomic(snap, {"proj/a.md": 0.8})
+    assert not list(tmp_path.glob("*.tmp"))
+    assert load_snapshot(snap) == {"proj/a.md": 0.8}
+
+def test_load_snapshot_missing_returns_empty(tmp_path):
+    assert load_snapshot(tmp_path / "nope.json") == {}
+
+def test_load_snapshot_corrupt_returns_empty(tmp_path):
+    p = tmp_path / "bad.json"; p.write_text("{not json", encoding="utf-8")
+    assert load_snapshot(p) == {}

--- a/tests/test_poi_memory_key.py
+++ b/tests/test_poi_memory_key.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from proof.poi_memory_key import derive_memory_key, memory_key_from_path
+
+
+def test_derive_basic():
+    assert derive_memory_key("C--Users-chunx", "session_x.md") == "C--Users-chunx/session_x.md"
+
+
+def test_derive_normalizes_raw_windows_project():
+    # 防御 V5 传未编码路径 C:\Users\chunx
+    assert derive_memory_key("C:\\Users\\chunx", "x.md") == "C--Users-chunx/x.md"
+
+
+def test_derive_strips_filename_dir():
+    # filename 只取 basename,防上游误传路径
+    assert derive_memory_key("proj", "memory/x.md") == "proj/x.md"
+
+
+def test_memory_key_from_full_path():
+    p = Path.home() / ".claude" / "projects" / "C--Users-chunx" / "memory" / "session_x.md"
+    assert memory_key_from_path(p) == "C--Users-chunx/session_x.md"
+
+
+def test_memory_key_from_path_filename_only_returns_none():
+    # 纯文件名无法定位 project → None(boost 侧据此回退 frontmatter)
+    assert memory_key_from_path("session_x.md") is None

--- a/tests/test_poi_memory_key.py
+++ b/tests/test_poi_memory_key.py
@@ -24,3 +24,21 @@ def test_memory_key_from_full_path():
 def test_memory_key_from_path_filename_only_returns_none():
     # 纯文件名无法定位 project → None(boost 侧据此回退 frontmatter)
     assert memory_key_from_path("session_x.md") is None
+
+
+def test_memory_key_from_nonstandard_path_returns_none():
+    # 无 'memory' 段的路径无法可靠定位 project · 锚定 'memory' 段而非盲取 parts[-3]
+    # 防 silent-mislabel(如云端 /var/lib/compass/poi/... 旧逻辑会错标 'poi/...')
+    assert memory_key_from_path("/var/lib/compass/poi/cycle-1/ingest_a.md") is None
+    assert memory_key_from_path("/a/b/c.md") is None  # 无 'memory' 段
+
+
+def test_memory_key_anchors_on_memory_segment_not_position():
+    # 即使 project 前后还有目录层级,仍锚定 'memory' 段取其前一级
+    p = "/home/u/.claude/projects/cycle-59717-auto/memory/session_y.md"
+    assert memory_key_from_path(p) == "cycle-59717-auto/session_y.md"
+
+
+def test_memory_key_memory_as_last_segment_returns_none():
+    # 'memory' 是末段(目录路径无文件)→ None
+    assert memory_key_from_path("/a/proj/memory") is None

--- a/tests/test_poi_normalization_equivalence.py
+++ b/tests/test_poi_normalization_equivalence.py
@@ -1,0 +1,72 @@
+"""Drift guard: the project-normalization logic exists in THREE places —
+  1. proof/poi_memory_key._normalize_project  (local · importable)
+  2. ops/patch_v14_recall_poi_boost.BOOST_HELPER      (cloud · inline raw-string)
+  3. ops/patch_v14_recall_poi_candidate.EMIT_HELPER   (cloud · inline raw-string)
+Copies 2/3 are injected verbatim into the cloud server (proof/ isn't importable
+there). If any copy drifts, cloud keys silently desync from local keys and joins
+against compass.poi_credit break with NO unit test catching it. This test execs
+the deployed cloud helpers and asserts byte-for-byte identical normalization to
+the local source of truth across a fixed corpus, so any drift fails CI.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from proof.poi_memory_key import _normalize_project
+from ops.patch_v14_recall_poi_boost import BOOST_HELPER
+from ops.patch_v14_recall_poi_candidate import EMIT_HELPER
+
+
+# project inputs spanning every branch of the normalization guard
+CORPUS = [
+    "C:\\Users\\chunx",   # windows backslash → encoded
+    "C:/Users/chunx",     # windows forward slash → encoded
+    "C--Users-chunx",     # already encoded → unchanged
+    "cycle-59717-auto",   # plain segment → unchanged
+    "/home/ubuntu/x",     # posix abs, no ':'/'\\' → guard false → unchanged
+    "a/b/c",              # rel slash, guard false → unchanged
+    "",                   # empty → ""
+]
+
+
+def _load_boost():
+    ns = {"_v14_os": os}
+    exec(BOOST_HELPER, ns)
+    return ns["_v14_poi_boost"]
+
+
+def _load_emit():
+    ns = {"_v14_os": os, "_v14_json": json}
+    exec(EMIT_HELPER, ns)
+    return ns["_v14_emit_poi_candidate"]
+
+
+@pytest.mark.parametrize("project", CORPUS)
+def test_boost_normalization_matches_local(project, tmp_path, monkeypatch):
+    """boost helper finds the credit iff its normalization == _normalize_project."""
+    expected = _normalize_project(project)
+    snap = tmp_path / "snap.json"
+    snap.write_text(json.dumps({expected + "/m.md": 5.0}), encoding="utf-8")  # ×1.5 (clamp 0.5)
+    monkeypatch.setenv("COMPASS_CLOUD_POI_BOOST", "1")
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    boost = _load_boost()
+    hits = [{"project": project, "path": "m.md", "score": 0.4}]
+    boost(hits)
+    # matched key → boosted 0.4×1.5=0.6; any normalization drift → miss → stays 0.4
+    assert round(hits[0]["score"], 4) == 0.6, (
+        f"boost normalization drifted for {project!r}: expected key prefix {expected!r}")
+
+
+@pytest.mark.parametrize("project", CORPUS)
+def test_emit_normalization_matches_local(project, tmp_path, monkeypatch):
+    """emit helper writes a project field == _normalize_project(project)."""
+    expected = _normalize_project(project)
+    monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
+    emit = _load_emit()
+    emit([{"path": "m.md", "project": project, "score": 0.5}], "q", "actor")
+    rec = json.loads((tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
+    assert rec["project"] == expected, (
+        f"emit normalization drifted for {project!r}: got {rec['project']!r} want {expected!r}")

--- a/tests/test_poi_reconcile_cron_wire.py
+++ b/tests/test_poi_reconcile_cron_wire.py
@@ -43,3 +43,17 @@ def test_settle_and_snapshot_no_match_writes_empty_snapshot(tmp_path):
     assert res["skipped_no_match"] == 1
     data = json.loads(snap.read_text(encoding="utf-8"))
     assert data == {}
+
+
+def test_dry_run_skips_snapshot(tmp_path):
+    cron = _load_cron()
+    conn = sqlite3.connect(":memory:"); conn.execute(CREATE)
+    snap = tmp_path / "poi_credit_cache.json"
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    res = cron.settle_and_snapshot(conn, [_cand()], outcomes, set(),
+                                   snapshot_path=snap, placeholder="?", dry_run=True)
+    assert res["settled"] == 1
+    # dry-run writes no snapshot and no DB rows
+    assert not snap.exists()
+    cnt = conn.execute("SELECT COUNT(*) FROM poi_credit").fetchone()[0]
+    assert cnt == 0

--- a/tests/test_poi_reconcile_cron_wire.py
+++ b/tests/test_poi_reconcile_cron_wire.py
@@ -1,0 +1,45 @@
+import json, sqlite3
+import importlib.util
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parents[1]
+
+
+def _load_cron():
+    spec = importlib.util.spec_from_file_location("poi_reconcile_cron", _HERE / "ops" / "poi_reconcile_cron.py")
+    mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); return mod
+
+
+CREATE = ("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, cumulative_impact REAL "
+          "NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+
+
+def _cand(actor="a1", project="proj", memory="m.md", creator="other", ts="2026-06-03T00:00:00+00:00", qh="q"):
+    return {"kind": "candidate", "actor": actor, "project": project, "memory": memory,
+            "creator": creator, "query_hash": qh, "ts": ts, "rank": 0, "score": 0.9}
+
+
+def test_settle_and_snapshot_writes_credit_and_snapshot(tmp_path):
+    cron = _load_cron()
+    conn = sqlite3.connect(":memory:"); conn.execute(CREATE)
+    snap = tmp_path / "poi_credit_cache.json"
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    res = cron.settle_and_snapshot(conn, [_cand()], outcomes, set(),
+                                   snapshot_path=snap, placeholder="?")
+    assert res["settled"] == 1
+    data = json.loads(snap.read_text(encoding="utf-8"))
+    assert "proj/m.md" in data and data["proj/m.md"] > 0
+
+
+def test_settle_and_snapshot_no_match_writes_empty_snapshot(tmp_path):
+    cron = _load_cron()
+    conn = sqlite3.connect(":memory:"); conn.execute(CREATE)
+    snap = tmp_path / "poi_credit_cache.json"
+    # outcome ts far outside the default window → no match
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2027-01-01T00:00:00+00:00"}]
+    res = cron.settle_and_snapshot(conn, [_cand()], outcomes, set(),
+                                   snapshot_path=snap, placeholder="?")
+    assert res["settled"] == 0
+    assert res["skipped_no_match"] == 1
+    data = json.loads(snap.read_text(encoding="utf-8"))
+    assert data == {}

--- a/tests/test_poi_reconciler_central.py
+++ b/tests/test_poi_reconciler_central.py
@@ -64,3 +64,14 @@ def test_dry_run_does_not_write_db():
     assert r["settled"] == 1
     cnt = conn.execute("SELECT COUNT(*) FROM poi_credit").fetchone()[0]
     assert cnt == 0
+
+
+def test_empty_project_skipped_no_degenerate_key():
+    # a candidate without project would derive a degenerate "/file" key · must skip
+    conn = _conn()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([_cand(project="")], outcomes, conn=conn, settled_keys=set(),
+                          placeholder="?")
+    assert r["settled"] == 0 and r["skipped_no_project"] == 1
+    cnt = conn.execute("SELECT COUNT(*) FROM poi_credit").fetchone()[0]
+    assert cnt == 0  # no degenerate "/m.md" row written

--- a/tests/test_poi_reconciler_central.py
+++ b/tests/test_poi_reconciler_central.py
@@ -38,3 +38,14 @@ def test_selfcite_dropped():
     outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
     r = reconcile_central([_cand(creator="a1")], outcomes, conn=conn, settled_keys=settled, placeholder="?")
     assert r["settled"] == 0 and r.get("skipped_selfcite") == 1
+
+
+def test_dry_run_does_not_write_db():
+    # dry_run=True counts what WOULD settle but writes nothing to the DB
+    conn = _conn()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([_cand()], outcomes, conn=conn, settled_keys=set(),
+                          placeholder="?", dry_run=True)
+    assert r["settled"] == 1
+    cnt = conn.execute("SELECT COUNT(*) FROM poi_credit").fetchone()[0]
+    assert cnt == 0

--- a/tests/test_poi_reconciler_central.py
+++ b/tests/test_poi_reconciler_central.py
@@ -1,5 +1,5 @@
 import sqlite3
-from proof.poi_reconciler import reconcile_central
+from proof.poi_reconciler import reconcile_central, central_candidate_key, candidate_key
 
 CREATE = ("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, cumulative_impact REAL "
           "NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
@@ -38,6 +38,21 @@ def test_selfcite_dropped():
     outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
     r = reconcile_central([_cand(creator="a1")], outcomes, conn=conn, settled_keys=settled, placeholder="?")
     assert r["settled"] == 0 and r.get("skipped_selfcite") == 1
+
+
+def test_central_key_matches_what_settle_persists():
+    # The key the cron pre-filter computes (central_candidate_key on the RAW
+    # candidate) must equal the key reconcile_central actually persists into
+    # settled_keys. Otherwise the pre-filter never matches → unbounded re-work.
+    conn = _conn(); settled = set()
+    raw = _cand()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([raw], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    assert r["settled"] == 1
+    # what the cron pre-filter would compute IS in the persisted set
+    assert central_candidate_key(raw) in settled
+    # and it differs from the raw key (proves the original bug: raw != central)
+    assert central_candidate_key(raw) != candidate_key(raw)
 
 
 def test_dry_run_does_not_write_db():

--- a/tests/test_poi_reconciler_central.py
+++ b/tests/test_poi_reconciler_central.py
@@ -1,0 +1,40 @@
+import sqlite3
+from proof.poi_reconciler import reconcile_central
+
+CREATE = ("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, cumulative_impact REAL "
+          "NOT NULL DEFAULT 0, event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+
+
+def _conn():
+    c = sqlite3.connect(":memory:"); c.execute(CREATE); return c
+
+
+def _cand(actor="a1", project="proj", memory="m.md", creator="other", ts="2026-06-03T00:00:00+00:00", qh="q"):
+    return {"kind": "candidate", "actor": actor, "project": project, "memory": memory,
+            "creator": creator, "query_hash": qh, "ts": ts, "rank": 0, "score": 0.9}
+
+
+def test_settle_writes_central_no_file_needed():
+    # 云端 memory · 本地无文件 · 仍 settle(M1 松绑)
+    conn = _conn(); settled = set()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([_cand()], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    assert r["settled"] == 1
+    row = conn.execute("SELECT cumulative_impact FROM poi_credit WHERE memory_key='proj/m.md'").fetchone()
+    assert row and row[0] > 0
+
+
+def test_rerun_idempotent_no_double_count():
+    conn = _conn(); settled = set()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    reconcile_central([_cand()], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    reconcile_central([_cand()], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    row = conn.execute("SELECT event_count FROM poi_credit WHERE memory_key='proj/m.md'").fetchone()
+    assert row[0] == 1  # 第二次被 settled_keys 挡住
+
+
+def test_selfcite_dropped():
+    conn = _conn(); settled = set()
+    outcomes = [{"agent_id": "a1", "success": True, "ts": "2026-06-03T00:10:00+00:00"}]
+    r = reconcile_central([_cand(creator="a1")], outcomes, conn=conn, settled_keys=settled, placeholder="?")
+    assert r["settled"] == 0 and r.get("skipped_selfcite") == 1

--- a/tests/test_poi_snapshot_cache.py
+++ b/tests/test_poi_snapshot_cache.py
@@ -1,0 +1,46 @@
+import json, time
+from pathlib import Path
+import recall_pkg.poi_snapshot_cache as C
+
+def _write(p, d):
+    p.write_text(json.dumps(d), encoding="utf-8")
+
+def test_loads_then_caches(tmp_path, monkeypatch):
+    snap = tmp_path / "poi_credit_cache.json"
+    _write(snap, {"proj/a.md": 1.0})
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    C.reset_cache()
+    assert C.get_credit_snapshot() == {"proj/a.md": 1.0}
+    # second call returns same dict without needing the file
+    assert C.get_credit_snapshot() == {"proj/a.md": 1.0}
+
+def test_reloads_on_mtime_change(tmp_path, monkeypatch):
+    snap = tmp_path / "poi_credit_cache.json"
+    _write(snap, {"proj/a.md": 1.0})
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    C.reset_cache()
+    assert C.get_credit_snapshot() == {"proj/a.md": 1.0}
+    time.sleep(0.01)
+    _write(snap, {"proj/a.md": 2.0, "proj/b.md": 5.0})
+    # force a different mtime (some filesystems are coarse)
+    import os
+    st = snap.stat()
+    os.utime(snap, (st.st_atime + 5, st.st_mtime + 5))
+    assert C.get_credit_snapshot() == {"proj/a.md": 2.0, "proj/b.md": 5.0}
+
+def test_missing_file_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(tmp_path / "nope.json"))
+    C.reset_cache()
+    assert C.get_credit_snapshot() == {}
+
+def test_corrupt_reload_keeps_last_good(tmp_path, monkeypatch):
+    snap = tmp_path / "poi_credit_cache.json"
+    _write(snap, {"proj/a.md": 1.0})
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    C.reset_cache()
+    assert C.get_credit_snapshot() == {"proj/a.md": 1.0}
+    # corrupt + bump mtime → reload attempts, fails, keeps last good
+    snap.write_text("{bad json", encoding="utf-8")
+    import os
+    st = snap.stat(); os.utime(snap, (st.st_atime + 5, st.st_mtime + 5))
+    assert C.get_credit_snapshot() == {"proj/a.md": 1.0}

--- a/tests/test_poi_snapshot_cache.py
+++ b/tests/test_poi_snapshot_cache.py
@@ -1,5 +1,4 @@
 import json, time
-from pathlib import Path
 import recall_pkg.poi_snapshot_cache as C
 
 def _write(p, d):

--- a/tests/test_poi_weighting_snapshot.py
+++ b/tests/test_poi_weighting_snapshot.py
@@ -1,4 +1,3 @@
-import math
 from recall_pkg.poi_weighting import apply_poi_boost_value, boost_top_k_with_snapshot
 
 

--- a/tests/test_poi_weighting_snapshot.py
+++ b/tests/test_poi_weighting_snapshot.py
@@ -1,0 +1,32 @@
+import math
+from recall_pkg.poi_weighting import apply_poi_boost_value, boost_top_k_with_snapshot
+
+
+def test_apply_value_basic():
+    # cumulative=5 → boost=clamp(0.5)=0.5 → 0.8*1.5=1.2
+    assert round(apply_poi_boost_value(0.8, 5.0), 4) == 1.2
+
+
+def test_apply_value_clamp_cap():
+    # cumulative=100 → boost capped at +1.0 → 0.5*2.0=1.0
+    assert round(apply_poi_boost_value(0.5, 100.0), 4) == 1.0
+
+
+def test_apply_value_clamp_floor():
+    assert round(apply_poi_boost_value(0.5, -100.0), 4) == 0.25  # *0.5
+
+
+def test_apply_value_nan_returns_base():
+    assert apply_poi_boost_value(0.7, float("nan")) == 0.7
+    assert apply_poi_boost_value(0.7, float("inf")) == 0.7
+
+
+def test_boost_with_snapshot_reranks():
+    snap = {"proj/hi.md": 5.0}
+    top = [
+        (0.50, {"path": "x", "fullpath": "/h/.claude/projects/proj/memory/lo.md"}),
+        (0.45, {"path": "y", "fullpath": "/h/.claude/projects/proj/memory/hi.md"}),
+    ]
+    out = boost_top_k_with_snapshot(top, snap)
+    # hi.md boosted 0.45*1.5=0.675 > lo.md 0.50 → reranked to top
+    assert "hi.md" in out[0][1]["fullpath"]

--- a/tests/test_sql_004_applies.py
+++ b/tests/test_sql_004_applies.py
@@ -1,0 +1,30 @@
+import re
+import sqlite3
+from pathlib import Path
+
+SQL_PATH = Path(__file__).resolve().parents[1] / "sql" / "004_poi_credit.sql"
+
+
+def _create_stmt_for_sqlite(sql_text: str) -> str:
+    # take only the CREATE TABLE ... ( ... ); statement
+    m = re.search(r"CREATE TABLE[^;]*;", sql_text, re.IGNORECASE | re.DOTALL)
+    assert m, "no CREATE TABLE found"
+    stmt = m.group(0)
+    stmt = stmt.replace("compass.", "")
+    stmt = stmt.replace("double precision", "REAL").replace("timestamptz", "TEXT")
+    stmt = stmt.replace("IF NOT EXISTS", "")  # keep simple
+    return stmt
+
+
+def test_create_table_parses_and_has_columns():
+    sql_text = SQL_PATH.read_text(encoding="utf-8")
+    stmt = _create_stmt_for_sqlite(sql_text)
+    conn = sqlite3.connect(":memory:")
+    conn.execute(stmt)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(poi_credit)")}
+    assert {"memory_key", "cumulative_impact", "event_count", "last_impact_at"} <= cols
+
+
+def test_has_grant_for_phase1():
+    sql_text = SQL_PATH.read_text(encoding="utf-8")
+    assert "GRANT" in sql_text.upper() and "poi_credit" in sql_text

--- a/tests/test_v14_poi_boost_patch.py
+++ b/tests/test_v14_poi_boost_patch.py
@@ -3,7 +3,6 @@ compass_http_v09.py). Mirrors the emission patch test: exec the helper into a
 namespace supplying _v14_os, then assert rerank behavior. NO daemon needed."""
 import os
 import json
-import pytest
 
 from ops.patch_v14_recall_poi_boost import BOOST_HELPER
 

--- a/tests/test_v14_poi_boost_patch.py
+++ b/tests/test_v14_poi_boost_patch.py
@@ -1,0 +1,71 @@
+"""Exec-test the cloud v14 PoI boost helper (BOOST_HELPER string deployed into
+compass_http_v09.py). Mirrors the emission patch test: exec the helper into a
+namespace supplying _v14_os, then assert rerank behavior. NO daemon needed."""
+import os
+import json
+import pytest
+
+from ops.patch_v14_recall_poi_boost import BOOST_HELPER
+
+
+def _load_helper():
+    ns = {"_v14_os": os}
+    exec(BOOST_HELPER, ns)
+    return ns["_v14_poi_boost"]
+
+
+def test_boost_reranks_credited(tmp_path, monkeypatch):
+    snap = tmp_path / "snap.json"
+    snap.write_text(json.dumps({"proj/hi.md": 5.0}), encoding="utf-8")  # boost clamp 0.5 → ×1.5
+    monkeypatch.setenv("COMPASS_CLOUD_POI_BOOST", "1")
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    boost = _load_helper()
+    hits = [{"project": "other", "path": "lo.md", "score": 0.6},
+            {"project": "proj", "path": "hi.md", "score": 0.45}]
+    boost(hits)
+    assert hits[0]["path"] == "hi.md"               # 0.45*1.5=0.675 > 0.6 → reranked top
+    assert round(hits[0]["score"], 4) == 0.675
+
+
+def test_boost_env_off_is_noop(tmp_path, monkeypatch):
+    snap = tmp_path / "snap.json"
+    snap.write_text(json.dumps({"proj/hi.md": 5.0}), encoding="utf-8")
+    monkeypatch.delenv("COMPASS_CLOUD_POI_BOOST", raising=False)
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    boost = _load_helper()
+    hits = [{"project": "proj", "path": "hi.md", "score": 0.45}]
+    boost(hits)
+    assert hits[0]["score"] == 0.45                 # boost off → untouched
+
+
+def test_boost_missing_snapshot_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("COMPASS_CLOUD_POI_BOOST", "1")
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(tmp_path / "nope.json"))
+    boost = _load_helper()
+    hits = [{"project": "p", "path": "a.md", "score": 0.5}]
+    boost(hits)
+    assert hits[0]["score"] == 0.5                  # no snapshot → graceful no-op
+
+
+def test_boost_only_credited_hits(tmp_path, monkeypatch):
+    snap = tmp_path / "s.json"
+    snap.write_text(json.dumps({"proj/hi.md": 3.0}), encoding="utf-8")  # ×1.3
+    monkeypatch.setenv("COMPASS_CLOUD_POI_BOOST", "1")
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    boost = _load_helper()
+    hits = [{"project": "proj", "path": "hi.md", "score": 0.5},
+            {"project": "x", "path": "y.md", "score": 0.4}]
+    boost(hits)
+    d = {h["path"]: h["score"] for h in hits}
+    assert round(d["hi.md"], 4) == 0.65 and d["y.md"] == 0.4  # uncredited unchanged
+
+
+def test_boost_normalizes_windows_project(tmp_path, monkeypatch):
+    snap = tmp_path / "s.json"
+    snap.write_text(json.dumps({"C--Users-chunx/m.md": 5.0}), encoding="utf-8")
+    monkeypatch.setenv("COMPASS_CLOUD_POI_BOOST", "1")
+    monkeypatch.setenv("COMPASS_POI_CREDIT_SNAPSHOT", str(snap))
+    boost = _load_helper()
+    hits = [{"project": "C:\\Users\\chunx", "path": "m.md", "score": 0.4}]
+    boost(hits)
+    assert round(hits[0]["score"], 4) == 0.6        # raw windows project normalized → matched

--- a/tests/test_v14_poi_emission_patch.py
+++ b/tests/test_v14_poi_emission_patch.py
@@ -31,7 +31,7 @@ def test_emits_one_line_per_hit(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
     hits = [{"path": "a.md", "score": 0.91}, {"path": "b.md", "score": 0.5}]
-    n = emit(hits, "some query", "nautilus-prime-001")
+    n = emit(hits, "some query", "nautilus-prime-001", "proj")
     assert n == 2
     lines = (tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
@@ -47,7 +47,7 @@ def test_emits_one_line_per_hit(tmp_path, monkeypatch):
 def test_none_agent_id_becomes_unknown(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([{"path": "a.md", "score": 0.1}], "q", None)
+    n = emit([{"path": "a.md", "score": 0.1}], "q", None, "proj")
     assert n == 1
     r = json.loads((tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
     assert r["actor"] == "unknown"
@@ -56,16 +56,27 @@ def test_none_agent_id_becomes_unknown(tmp_path, monkeypatch):
 def test_skips_hits_without_path(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([{"score": 0.1}, {"path": "b.md", "score": 0.2}], "q", "x")
+    n = emit([{"score": 0.1}, {"path": "b.md", "score": 0.2}], "q", "x", "proj")
     assert n == 1
 
 
 def test_empty_hits_writes_nothing(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([], "q", "x")
+    n = emit([], "q", "x", "proj")
     assert n == 0
     assert not (tmp_path / "poi_candidates.jsonl").exists()
+
+
+def test_carries_normalized_project(tmp_path, monkeypatch):
+    """4-arg signature · project normalized to encoded_cwd form (P0-1 contract:
+    cloud inline emit must match proof/poi_memory_key._normalize_project)."""
+    monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
+    emit = _load_emit()
+    n = emit([{"path": "a.md", "score": 0.5}], "q", "actor-1", "C:\\Users\\chunx")
+    assert n == 1
+    r = json.loads((tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
+    assert r["project"] == "C--Users-chunx"
 
 
 # ---- patch application (against a synthetic copy of the live route) -----------
@@ -122,7 +133,7 @@ def test_patch_adds_agent_id_param_and_emit_and_helper(tmp_path):
     out = target.read_text(encoding="utf-8")
     assert "agent_id: Optional[str] = None" in out
     assert "def _v14_emit_poi_candidate(" in out
-    assert "_v14_emit_poi_candidate(_h, q, agent_id)" in out
+    assert "_v14_emit_poi_candidate(_h, q, agent_id, project)" in out
     # patched module must still be importable Python
     compile(out, "patched", "exec")
 
@@ -148,8 +159,9 @@ def test_patched_route_emits_on_real_call(tmp_path, monkeypatch):
           "_call_v14_daemon": lambda req, timeout=None: {"ok": True, "recall": [{"path": "m.md", "score": 0.7}]},
           "_v14_os": os, "_v14_json": json}
     exec(compile(target.read_text(encoding="utf-8"), "patched", "exec"), ns)
-    res = ns["v14_recall"]("hello", agent_id="nautilus-prime-001")
+    res = ns["v14_recall"]("hello", agent_id="nautilus-prime-001", project="C:\\Users\\chunx")
     assert res["ok"] is True
     line = json.loads((tmp_path / "poi" / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
     assert line["actor"] == "nautilus-prime-001"
     assert line["memory"] == "m.md"
+    assert line["project"] == "C--Users-chunx"

--- a/tests/test_v14_poi_emission_patch.py
+++ b/tests/test_v14_poi_emission_patch.py
@@ -31,7 +31,7 @@ def test_emits_one_line_per_hit(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
     hits = [{"path": "a.md", "score": 0.91}, {"path": "b.md", "score": 0.5}]
-    n = emit(hits, "some query", "nautilus-prime-001", "proj")
+    n = emit(hits, "some query", "nautilus-prime-001")
     assert n == 2
     lines = (tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 2
@@ -47,7 +47,7 @@ def test_emits_one_line_per_hit(tmp_path, monkeypatch):
 def test_none_agent_id_becomes_unknown(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([{"path": "a.md", "score": 0.1}], "q", None, "proj")
+    n = emit([{"path": "a.md", "score": 0.1}], "q", None)
     assert n == 1
     r = json.loads((tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
     assert r["actor"] == "unknown"
@@ -56,27 +56,36 @@ def test_none_agent_id_becomes_unknown(tmp_path, monkeypatch):
 def test_skips_hits_without_path(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([{"score": 0.1}, {"path": "b.md", "score": 0.2}], "q", "x", "proj")
+    n = emit([{"score": 0.1}, {"path": "b.md", "score": 0.2}], "q", "x")
     assert n == 1
 
 
 def test_empty_hits_writes_nothing(tmp_path, monkeypatch):
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([], "q", "x", "proj")
+    n = emit([], "q", "x")
     assert n == 0
     assert not (tmp_path / "poi_candidates.jsonl").exists()
 
 
-def test_carries_normalized_project(tmp_path, monkeypatch):
-    """4-arg signature · project normalized to encoded_cwd form (P0-1 contract:
-    cloud inline emit must match proof/poi_memory_key._normalize_project)."""
+def test_carries_per_hit_project(tmp_path, monkeypatch):
+    """3-arg signature · project derived PER HIT from each hit's own `project`
+    field (scope=user correctness: one recall returns hits from different
+    projects; daemon already tags each hit with its project). Each written
+    candidate carries its hit's project, normalized to encoded_cwd form."""
     monkeypatch.setenv("COMPASS_POI_CACHE_DIR", str(tmp_path))
     emit = _load_emit()
-    n = emit([{"path": "a.md", "score": 0.5}], "q", "actor-1", "C:\\Users\\chunx")
-    assert n == 1
-    r = json.loads((tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
-    assert r["project"] == "C--Users-chunx"
+    hits = [
+        {"path": "a.md", "project": "cycle-59717-auto", "score": 0.9},
+        {"path": "b.md", "project": "C:\\Users\\chunx", "score": 0.8},
+    ]
+    n = emit(hits, "q", "actor-1")
+    assert n == 2
+    lines = (tmp_path / "poi_candidates.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    r0 = json.loads(lines[0])
+    r1 = json.loads(lines[1])
+    assert r0["project"] == "cycle-59717-auto"   # already plain · unchanged
+    assert r1["project"] == "C--Users-chunx"      # windows path · normalized
 
 
 # ---- patch application (against a synthetic copy of the live route) -----------
@@ -133,7 +142,7 @@ def test_patch_adds_agent_id_param_and_emit_and_helper(tmp_path):
     out = target.read_text(encoding="utf-8")
     assert "agent_id: Optional[str] = None" in out
     assert "def _v14_emit_poi_candidate(" in out
-    assert "_v14_emit_poi_candidate(_h, q, agent_id, project)" in out
+    assert "_v14_emit_poi_candidate(_h, q, agent_id)" in out
     # patched module must still be importable Python
     compile(out, "patched", "exec")
 
@@ -155,13 +164,22 @@ def test_patched_route_emits_on_real_call(tmp_path, monkeypatch):
     def _Header(default=None, alias=None):
         return default
 
+    daemon_hits = [
+        {"path": "m.md", "project": "cycle-59717-auto", "score": 0.7},
+        {"path": "n.md", "project": "C:\\Users\\chunx", "score": 0.6},
+    ]
     ns = {"app": _App(), "Header": _Header,
-          "_call_v14_daemon": lambda req, timeout=None: {"ok": True, "recall": [{"path": "m.md", "score": 0.7}]},
+          "_call_v14_daemon": lambda req, timeout=None: {"ok": True, "recall": daemon_hits},
           "_v14_os": os, "_v14_json": json}
     exec(compile(target.read_text(encoding="utf-8"), "patched", "exec"), ns)
-    res = ns["v14_recall"]("hello", agent_id="nautilus-prime-001", project="C:\\Users\\chunx")
+    # scope=user: requester's project context is irrelevant; each hit carries its own.
+    res = ns["v14_recall"]("hello", scope="user", agent_id="nautilus-prime-001")
     assert res["ok"] is True
-    line = json.loads((tmp_path / "poi" / "poi_candidates.jsonl").read_text(encoding="utf-8").strip())
-    assert line["actor"] == "nautilus-prime-001"
-    assert line["memory"] == "m.md"
-    assert line["project"] == "C--Users-chunx"
+    lines = (tmp_path / "poi" / "poi_candidates.jsonl").read_text(encoding="utf-8").strip().splitlines()
+    r0 = json.loads(lines[0])
+    r1 = json.loads(lines[1])
+    assert r0["actor"] == "nautilus-prime-001"
+    assert r0["memory"] == "m.md"
+    assert r0["project"] == "cycle-59717-auto"   # per-hit · already plain
+    assert r1["memory"] == "n.md"
+    assert r1["project"] == "C--Users-chunx"      # per-hit · normalized


### PR DESCRIPTION
## What
Migrate PoI credit from per-file frontmatter (host-bound) to a cloud single table `compass.poi_credit`, keyed by `memory_key = project/filename`. Closes the cross-host gap where V5's cloud recalls couldn't accumulate credit (settled=0). **L3 PoI recursive loop now closed end-to-end for V5.**

Design: `docs/plans/2026-06-03-poi-central-ledger-design.md` · Plan: `...-implementation.md`
Brainstorming + 3-perspective review (architecture / failure-safety / YAGNI) reduced the original ledger+aggregate to a single table.

## Phase 1 — central table + local pipeline ✅
- `derive_memory_key` single-source · `poi_credit_store` (UPSERT + atomic snapshot) · `boost_top_k_with_snapshot` (NaN/clamp guard) · `reconcile_central` (writes table, M1 relaxed, DB self-cite, dry-run zero-write) · cron wiring · `sql/004` table+grant.
- Cross-cutting P0s folded in. **716 unit tests.**

## Phase 2 — V5 closure, DEPLOYED + PRODUCTION-VERIFIED ✅
- **Emission**: cloud v14 recall now emits candidates with **per-hit `project`** (V5 uses scope=user / cross-project; the daemon already tags each hit's project — a single query-param would mislabel). Deployed to live `compass_http_v09.py`.
- **Reconcile**: real `nautilus-prime-001` fuel → `settled=6` into `compass.poi_credit` with correct keys (`cycle-*/ingest_*.md`, `C--Users-chunx/session_*.md`).
- **Cloud boost**: `_v14_poi_boost` reranks V5's recall hits by the credit snapshot · env-gated `COMPASS_CLOUD_POI_BOOST` (default OFF) · mtime-cached · never raises. **Verified: credited memory 0.7830 → 0.8091 (×1.0333 for credit 0.3333); uncredited hits unchanged.**
- **Snapshot delivery**: `regen_poi_snapshot.sh` cron regenerates the snapshot on-cloud from the table (source of truth) every 10min → `/var/lib/compass/poi` (sandbox whitelist).

## e2e surfaced & fixed (unit tests missed these)
readonly DB connection → writable; missing schema USAGE grant; schema-unqualified SQL → search_path; cron pre-filter key mismatch; idempotent-skip not updating old helper (surgical replace); empty-project degenerate-key defense.

## Status
**721 unit tests green · 17 commits.** Phase 1+2 deployed and verified in production. `cnt_compass_v5_recall_demand_c1` delivered. Remaining (Phase 3): dedicated `poi_writer` role to tighten the `compass_sub` write grant; multi-host idempotency table. Ready for review — merge at maintainer's discretion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)