### PR TITLE
fix(bridge): decode stdin as UTF-8, not Windows gbk (CJK obs ingest crash)

### DIFF
--- a/ops/mcp_stdio_to_cloud.py
+++ b/ops/mcp_stdio_to_cloud.py
@@ -340,6 +340,19 @@ def _make_rpc_error(msg_id, code: int, message: str) -> bytes:
     return (json.dumps(resp) + "\n").encode("utf-8")
 
 
+def _decode_line(raw: bytes) -> str:
+    """Decode one stdin line as UTF-8 — the MCP JSON-RPC stream is ALWAYS UTF-8.
+
+    Do NOT rely on text-mode sys.stdin: on a Chinese Windows host it defaults to
+    gbk + surrogateescape, which turns a CJK obs name's UTF-8 bytes into lone
+    surrogates (\\udcXX). Those survive json.dumps (as \\uXXXX escapes) and then
+    detonate cloud-side on strict utf-8 re-encode → "tool ingest_obs failed:
+    surrogates not allowed" (the 跨设备 obs ingest bug, 2026-06-05). errors=
+    'replace' keeps the bridge crash-proof on a stray non-utf8 byte without ever
+    producing a surrogate."""
+    return raw.decode("utf-8", errors="replace")
+
+
 def _pump_in_to_cloud(cloud) -> None:
     """stdin → (local stub | local daemon | inject auth → cloud TCP) / stdout.
 
@@ -348,7 +361,10 @@ def _pump_in_to_cloud(cloud) -> None:
     return a JSON-RPC error to the caller.
     """
     cloud_available = cloud is not None
-    for raw in sys.stdin:
+    # read BINARY stdin and decode UTF-8 ourselves · text-mode sys.stdin uses the
+    # Windows console code page (gbk) which corrupts CJK into lone surrogates.
+    for raw_bytes in sys.stdin.buffer:
+        raw = _decode_line(raw_bytes)
         if not raw.strip():
             continue
         line = raw.rstrip("\n")

--- a/tests/test_bridge_stdin_utf8.py
+++ b/tests/test_bridge_stdin_utf8.py
@@ -1,0 +1,57 @@
+"""Bridge stdin must decode UTF-8, never the Windows console code page.
+
+Root cause (SSH+repro confirmed 2026-06-05): on a Chinese Windows host
+sys.stdin defaults to gbk + surrogateescape. The MCP JSON-RPC stream is ALWAYS
+UTF-8, so reading a CJK obs name through gbk turns its UTF-8 bytes into lone
+surrogates (\\udcXX), which then crash downstream strict utf-8 re-encoding
+(cloud-side: "tool ingest_obs failed: surrogates not allowed"). The 跨设备 obs
+ingest bug. Fix: decode stdin bytes as UTF-8 explicitly.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN))
+# the bridge module exits at import if no cloud token env is set (it's a runtime
+# guard); set a dummy so we can import and unit-test the pure _decode_line helper.
+os.environ.setdefault("COMPASS_CLOUD_TOKEN", "test-dummy-token")
+bridge = importlib.import_module("ops.mcp_stdio_to_cloud")
+
+
+def test_decode_line_exists():
+    assert hasattr(bridge, "_decode_line")
+
+
+def test_cjk_name_decodes_clean():
+    # exactly what Claude Code writes to the bridge's stdin pipe
+    raw = '{"name":"跨设备测试obs"}\n'.encode("utf-8")
+    out = bridge._decode_line(raw)
+    assert "跨设备测试obs" in out
+    # CRITICAL: no lone surrogates (the bug signature)
+    assert not any("\udc80" <= c <= "\udcff" for c in out)
+    # and it must round-trip back to utf-8 without crashing (the reported error)
+    out.rstrip("\n").encode("utf-8")  # must not raise
+
+
+def test_middle_dot_and_punctuation_preserved():
+    # "·" (U+00B7) was mangled in the live repro; ensure punctuation survives
+    raw = '{"description":"marker · 路标 测试"}\n'.encode("utf-8")
+    out = bridge._decode_line(raw)
+    assert "·" in out and "路标" in out
+
+
+def test_ascii_unchanged():
+    raw = b'{"name":"xdev-probe-9173"}\n'
+    assert bridge._decode_line(raw) == '{"name":"xdev-probe-9173"}\n'
+
+
+def test_invalid_bytes_do_not_crash_or_surrogate():
+    # a stray non-utf8 byte must not raise and must not yield a lone surrogate
+    raw = b'{"x":"\xae"}\n'
+    out = bridge._decode_line(raw)
+    assert not any("\udc80" <= c <= "\udcff" for c in out)
+    out.encode("utf-8")  # must not raise


### PR DESCRIPTION
## Summary
Fixes the cross-device obs ingest crash on CJK names (`-32603 tool ingest_obs failed: 'utf-8' codec can't encode character '\udcae': surrogates not allowed`).

**Root cause (SSH + local repro confirmed):** on a Chinese Windows host `sys.stdin` defaults to **gbk + surrogateescape**. The MCP JSON-RPC stream is always UTF-8, so a CJK obs name's UTF-8 bytes get mis-decoded into lone surrogates (`\udcXX`). They survive `json.dumps` (as `\uXXXX` escapes), reach the cloud, and detonate on strict utf-8 re-encode when the cloud writes the obs file.

**Fix:** read `sys.stdin.buffer` (binary) and decode UTF-8 explicitly via `_decode_line` (`errors=replace` — crash-proof, never yields a surrogate). Bypasses the text-mode gbk layer entirely.

This unblocks a whole class of cross-device ingests (most real obs names are Chinese).

## Test Plan
- [x] 5 TDD unit tests (CJK name clean / no surrogates / round-trips, punctuation `·`+CJK preserved, ASCII unchanged, stray non-utf8 byte no-crash-no-surrogate)
- [x] ruff clean on changed files
- [x] root cause reproduced exactly (gbk decode of UTF-8 CJK → `\udcae` → strict re-encode crash)
- [ ] live e2e deferred — compass-cloud MCP currently disconnected; verify after plugin redeploy + Claude Code restart by ingesting an obs with a Chinese name and recalling it

## Deploy note
Edits the repo `ops/mcp_stdio_to_cloud.py`; the live bridge is the plugin copy at `~/.claude/plugins/nautilus-compass/ops/` — takes effect after plugin sync + MCP restart.