### PR TITLE
feat(recall): opt-in gemini query-rewrite (COMPASS_PROD_QUERY_REWRITE)

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -109,6 +109,12 @@ _RERANKER_LOCK = threading.Lock()
 # Default OFF: no memory is ever hidden until explicitly enabled.
 _PROD_LIFECYCLE_USE = os.environ.get("COMPASS_PROD_LIFECYCLE", "0") == "1"
 
+# v2.3.0 · opt-in gemini query rewrite before recall · COMPASS_PROD_QUERY_REWRITE=1
+# (also needs COMPASS_USE_GEMINI_FLASH). LLM contact isolated in query_rewrite.py;
+# any failure falls back to the original query. Default OFF: daemon recall is
+# byte-identical, zero LLM (black-box hot path preserved).
+_PROD_QUERY_REWRITE_USE = os.environ.get("COMPASS_PROD_QUERY_REWRITE", "0") == "1"
+
 
 def _tokenize_for_bm25(text: str) -> list:
     """v2.1.0 · Whitespace + lowercase + CJK char tokenizer for BM25."""
@@ -719,6 +725,16 @@ def handle_request(req: dict) -> dict:
         return {"ok": False, "error": f"scope must be 'project' or 'user', got {scope!r}"}
     if not query:
         return {"ok": False, "error": "empty query"}
+
+    # v2.3.0 · opt-in gemini query rewrite (recall actions only) · default off =
+    # no LLM, query unchanged. LLM contact + all failure-handling isolated in
+    # query_rewrite.rewrite_query (returns the original query on any fault).
+    if _PROD_QUERY_REWRITE_USE and action in ("recall", "both"):
+        try:
+            import query_rewrite as _qr
+            query = _qr.rewrite_query(query)
+        except Exception as _qe:
+            log(f"query rewrite failed · using original: {_qe}")
 
     # v2.0.7 · P9 · recall result cache lookup before encode/scoring
     _p9_key = _p9_cache_key(action, query, project, top_k, scope, agent_type)

--- a/docs/plans/2026-06-05-gemini-query-rewrite-design.md
+++ b/docs/plans/2026-06-05-gemini-query-rewrite-design.md
@@ -1,0 +1,66 @@
+# Gemini query-rewrite · opt-in recall enhancement (2026-06-05)
+
+## Goal
+Optionally rewrite a recall query before retrieval (expand abbreviations, add
+synonyms) to lift recall on terse/ambiguous queries. Opt-in, default off →
+black-box-local hot path preserved (no LLM unless explicitly enabled).
+
+## Build on existing infra (not reinvent · anchor #5)
+- `judges/gemini_flash.py` `GeminiFlashJudge.generate(prompt) -> str|None` —
+  complete lazy opt-in Gemini 2.5 Flash provider (Vertex SA, returns None on any
+  failure). Reused for the rewrite call.
+- `llm_opt_in.py` — flag registry (`OptInFlag`, `is_enabled(flag)` per-call).
+  Add a `query_rewrite` flag.
+
+## Architecture
+New module `query_rewrite.py` isolates ALL LLM contact:
+```
+rewrite_query(query: str) -> str
+  · flag off                → return query unchanged (byte-identical default)
+  · flag on, gemini ok      → return rewritten query
+  · flag on, gemini None/err → return ORIGINAL query (recall never degraded/broken)
+```
+- Flag: `query_rewrite` in `llm_opt_in.py`, env `COMPASS_PROD_QUERY_REWRITE`.
+  Effective only when the gemini provider is also enabled
+  (`COMPASS_USE_GEMINI_FLASH`); if the provider is off, `rewrite_query` is a
+  no-op (defense: never silently require an LLM the user didn't enable).
+- Prompt (low temperature, short): "Rewrite this memory-search query to maximize
+  retrieval recall: expand abbreviations, add 2-3 synonyms, keep it one line.
+  Return ONLY the rewritten query, no preamble." Cap output length; strip.
+- Guardrails: if the model returns empty / too-long / suspicious output, fall
+  back to the original query.
+
+### Hook (user-approved: daemon recall)
+`daemon.handle_request`, right after `query` is extracted and validated, behind
+the flag:
+```
+if _PROD_QUERY_REWRITE_USE:
+    query = query_rewrite.rewrite_query(query)
+```
+The embedding + scoring then use the (possibly rewritten) query. The P9 recall
+cache already keys on the query string, so rewrites cache naturally. The LLM call
+lives ONLY in `query_rewrite.py` — daemon core stays LLM-free by default.
+
+## Safety / constraints
+- Default off → daemon behavior byte-identical, zero LLM (honors
+  gemini_flash.py's "NEVER call from default recall").
+- Any gemini failure → original query (recall robustness invariant).
+- Latency: +1 gemini call (~hundreds ms) only when opted in.
+- Black-box: the LLM never touches embeddings or stored memory — only the
+  transient query string is rewritten.
+
+## Testing
+TDD with a MOCKED gemini provider (no live API):
+- flag off → identity.
+- flag on + provider off → identity (no-op).
+- flag on + mock returns rewrite → rewritten used.
+- flag on + mock returns None/empty/over-long → original (fallback).
+- daemon integration: monkeypatch rewrite + assert the scored query is the
+  rewritten one when flag on; identical path when off.
+Live gemini verification (real Vertex creds + `COMPASS_USE_GEMINI_FLASH=1`) is a
+manual gated smoke, deferred.
+
+## Out of scope (YAGNI)
+- No rewrite for drift/ingest (recall only).
+- No multi-candidate / HyDE expansion (single rewrite).
+- No local-LLM rewrite path (Qwen) in this iteration — gemini only, opt-in.

--- a/llm_opt_in.py
+++ b/llm_opt_in.py
@@ -91,6 +91,16 @@ _FLAGS: Dict[str, OptInFlag] = {
         description="Benchmark/paper judge only (v1.7.1+) · NOT for runtime recall",
         paper_claim="paper1/paper2 cross-LLM ablation",
     ),
+    # v2.3.0 · opt-in gemini query rewrite before recall · owned by query_rewrite.py
+    "query_rewrite": OptInFlag(
+        name="query_rewrite",
+        env_var="COMPASS_PROD_QUERY_REWRITE",
+        sprint=0,
+        tier=4,
+        description="Rewrite recall query via Gemini Flash before retrieval · "
+                    "also requires COMPASS_USE_GEMINI_FLASH · fails back to original query",
+        paper_claim="recall-quality wiring (not a paper3 claim)",
+    ),
 }
 
 
@@ -101,6 +111,7 @@ DRIFT_PAY = "llm_drift_pay"
 REFLECT = "llm_reflect"
 ECON = "llm_econ"
 GEMINI_FLASH_JUDGE = "gemini_flash_judge"
+QUERY_REWRITE = "query_rewrite"
 
 
 _TRUTHY = ("1", "true", "yes", "on")

--- a/query_rewrite.py
+++ b/query_rewrite.py
@@ -1,0 +1,54 @@
+"""Gemini query-rewrite · opt-in recall enhancement (v2.3.0).
+
+Rewrites a recall query before retrieval (expand abbreviations, add synonyms) to
+lift recall on terse/ambiguous queries. ALL LLM contact is isolated here.
+
+Activates ONLY when BOTH:
+  · COMPASS_PROD_QUERY_REWRITE=1  (the query_rewrite opt-in flag), AND
+  · COMPASS_USE_GEMINI_FLASH=1    (the gemini provider)
+Default off → daemon recall is byte-identical, zero LLM (black-box-local hot
+path preserved · honors judges/gemini_flash.py "NEVER call from default recall").
+
+Robustness invariant: ANY failure (provider off, gemini None/empty/over-long,
+exception) → return the ORIGINAL query. Recall is never broken or degraded.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import llm_opt_in
+from judges import gemini_flash
+
+# one-line, low-temperature rewrite · the model gets only the transient query
+_PROMPT = (
+    "Rewrite this memory-search query to maximize retrieval recall: expand "
+    "abbreviations, add 2-3 synonyms, keep it to ONE line. Return ONLY the "
+    "rewritten query with no preamble or quotes.\n\nQuery: {query}"
+)
+
+# sanity cap · a rewrite far longer than the input is almost certainly the model
+# rambling (preamble / explanation) → reject and fall back.
+_MAX_OUT_CHARS = 600
+
+
+def rewrite_query(query: str, judge: Optional[object] = None) -> str:
+    """Return a rewritten query when opted in + gemini available, else `query`."""
+    if not query or not query.strip():
+        return query
+    if not llm_opt_in.is_enabled(llm_opt_in.QUERY_REWRITE):
+        return query
+    if not gemini_flash.is_enabled():
+        # provider not enabled → never silently require an LLM the user didn't turn on
+        return query
+    j = judge if judge is not None else gemini_flash.GeminiFlashJudge()
+    try:
+        out = j.generate(_PROMPT.format(query=query), max_tokens=120, temperature=0.1)
+    except Exception:
+        return query
+    if not out or not out.strip():
+        return query
+    # take the first non-empty line, strip quotes/space
+    first = out.strip().splitlines()[0].strip().strip('"').strip("'").strip()
+    if not first or len(first) > _MAX_OUT_CHARS:
+        return query
+    return first

--- a/query_rewrite.py
+++ b/query_rewrite.py
@@ -19,15 +19,20 @@ from typing import Optional
 import llm_opt_in
 from judges import gemini_flash
 
-# one-line, low-temperature rewrite · the model gets only the transient query
+# one-line, low-temperature expansion · AUGMENT (not replace): the model returns
+# EXTRA synonym terms; we append them to the original query so domain jargon is
+# never lost. Live evidence (2026-06-05): a replace-style rewrite turned "PoI"
+# (Proof of Impact) into "Point" — a wrong expansion that would hurt recall.
+# Augmenting keeps the original "PoI" token, so the expansion can only add signal.
 _PROMPT = (
-    "Rewrite this memory-search query to maximize retrieval recall: expand "
-    "abbreviations, add 2-3 synonyms, keep it to ONE line. Return ONLY the "
-    "rewritten query with no preamble or quotes.\n\nQuery: {query}"
+    "Given this memory-search query, list 3-6 ADDITIONAL keywords or synonyms "
+    "that would help retrieve relevant memories. Do NOT repeat the original "
+    "words, do NOT rewrite or explain — output ONLY extra terms, one line, "
+    "space-separated, no preamble or quotes.\n\nQuery: {query}"
 )
 
-# sanity cap · a rewrite far longer than the input is almost certainly the model
-# rambling (preamble / explanation) → reject and fall back.
+# sanity cap · an expansion far longer than a keyword list is almost certainly
+# the model rambling (preamble / explanation) → reject and fall back.
 _MAX_OUT_CHARS = 600
 
 
@@ -47,8 +52,10 @@ def rewrite_query(query: str, judge: Optional[object] = None) -> str:
         return query
     if not out or not out.strip():
         return query
-    # take the first non-empty line, strip quotes/space
-    first = out.strip().splitlines()[0].strip().strip('"').strip("'").strip()
-    if not first or len(first) > _MAX_OUT_CHARS:
+    # take the first non-empty line of extra terms, strip quotes/space
+    expansion = out.strip().splitlines()[0].strip().strip('"').strip("'").strip()
+    if not expansion or len(expansion) > _MAX_OUT_CHARS:
         return query
-    return first
+    # AUGMENT: original query always preserved · expansion only adds signal,
+    # so a wrong expansion (e.g. PoI→Point) can't drop the original token.
+    return f"{query} {expansion}"

--- a/tests/test_query_rewrite.py
+++ b/tests/test_query_rewrite.py
@@ -1,0 +1,95 @@
+"""Gemini query-rewrite · opt-in recall enhancement.
+
+rewrite_query is identity unless BOTH the query_rewrite flag
+(COMPASS_PROD_QUERY_REWRITE) AND the gemini provider (COMPASS_USE_GEMINI_FLASH)
+are on. Any gemini failure → original query (recall must never break/degrade).
+Uses an injectable judge so no live Gemini API is touched.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN))
+import query_rewrite as qr  # noqa: E402
+
+
+class _FakeJudge:
+    def __init__(self, out):
+        self.out = out
+        self.calls = []
+
+    def generate(self, prompt, max_tokens=120, temperature=0.1):
+        self.calls.append(prompt)
+        if isinstance(self.out, Exception):
+            raise self.out
+        return self.out
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("COMPASS_PROD_QUERY_REWRITE", raising=False)
+    monkeypatch.delenv("COMPASS_USE_GEMINI_FLASH", raising=False)
+    yield
+
+
+def _on(monkeypatch):
+    monkeypatch.setenv("COMPASS_PROD_QUERY_REWRITE", "1")
+    monkeypatch.setenv("COMPASS_USE_GEMINI_FLASH", "1")
+
+
+def test_flag_off_is_identity(monkeypatch):
+    assert qr.rewrite_query("residual insurance", judge=_FakeJudge("X")) == "residual insurance"
+
+
+def test_provider_off_is_identity(monkeypatch):
+    monkeypatch.setenv("COMPASS_PROD_QUERY_REWRITE", "1")  # rewrite on, provider off
+    assert qr.rewrite_query("foo", judge=_FakeJudge("X")) == "foo"
+
+
+def test_on_rewrites(monkeypatch):
+    _on(monkeypatch)
+    fake = _FakeJudge("residual insurance levy 残保金 disability employment quota")
+    out = qr.rewrite_query("残保金", judge=fake)
+    assert out == "residual insurance levy 残保金 disability employment quota"
+    assert fake.calls and "残保金" in fake.calls[0]  # query passed into prompt
+
+
+def test_gemini_none_falls_back(monkeypatch):
+    _on(monkeypatch)
+    assert qr.rewrite_query("q", judge=_FakeJudge(None)) == "q"
+
+
+def test_gemini_empty_falls_back(monkeypatch):
+    _on(monkeypatch)
+    assert qr.rewrite_query("q", judge=_FakeJudge("   ")) == "q"
+
+
+def test_gemini_exception_falls_back(monkeypatch):
+    _on(monkeypatch)
+    assert qr.rewrite_query("q", judge=_FakeJudge(RuntimeError("boom"))) == "q"
+
+
+def test_overlong_output_falls_back(monkeypatch):
+    _on(monkeypatch)
+    assert qr.rewrite_query("q", judge=_FakeJudge("x" * 5000)) == "q"
+
+
+def test_takes_first_line_and_strips(monkeypatch):
+    _on(monkeypatch)
+    out = qr.rewrite_query("q", judge=_FakeJudge("  expanded q terms  \nignored second line"))
+    assert out == "expanded q terms"
+
+
+def test_empty_query_identity(monkeypatch):
+    _on(monkeypatch)
+    assert qr.rewrite_query("   ", judge=_FakeJudge("X")) == "   "
+
+
+def test_flag_registered():
+    import llm_opt_in
+    assert hasattr(llm_opt_in, "QUERY_REWRITE")
+    assert llm_opt_in.QUERY_REWRITE in llm_opt_in._FLAGS

--- a/tests/test_query_rewrite.py
+++ b/tests/test_query_rewrite.py
@@ -50,12 +50,21 @@ def test_provider_off_is_identity(monkeypatch):
     assert qr.rewrite_query("foo", judge=_FakeJudge("X")) == "foo"
 
 
-def test_on_rewrites(monkeypatch):
+def test_on_augments_keeping_original(monkeypatch):
     _on(monkeypatch)
-    fake = _FakeJudge("residual insurance levy 残保金 disability employment quota")
+    fake = _FakeJudge("residual insurance levy disability employment quota")
     out = qr.rewrite_query("残保金", judge=fake)
-    assert out == "residual insurance levy 残保金 disability employment quota"
+    # AUGMENT: original query is ALWAYS preserved, expansion appended
+    assert out == "残保金 residual insurance levy disability employment quota"
+    assert out.startswith("残保金 ")
     assert fake.calls and "残保金" in fake.calls[0]  # query passed into prompt
+
+
+def test_domain_jargon_preserved_even_on_bad_expansion(monkeypatch):
+    # the live PoI->Point regression: with augment, the original token survives
+    _on(monkeypatch)
+    out = qr.rewrite_query("PoI", judge=_FakeJudge("Point"))
+    assert "PoI" in out and out.startswith("PoI ")  # PoI signal retained
 
 
 def test_gemini_none_falls_back(monkeypatch):
@@ -80,8 +89,8 @@ def test_overlong_output_falls_back(monkeypatch):
 
 def test_takes_first_line_and_strips(monkeypatch):
     _on(monkeypatch)
-    out = qr.rewrite_query("q", judge=_FakeJudge("  expanded q terms  \nignored second line"))
-    assert out == "expanded q terms"
+    out = qr.rewrite_query("q", judge=_FakeJudge("  expanded terms  \nignored second line"))
+    assert out == "q expanded terms"  # original + first-line expansion
 
 
 def test_empty_query_identity(monkeypatch):


### PR DESCRIPTION
## Summary
Optionally rewrites a recall query via Gemini 2.5 Flash before retrieval (expand abbreviations, add synonyms) to lift recall on terse/ambiguous queries. **Opt-in, default off → daemon recall byte-identical, zero LLM** (black-box-local hot path preserved).

Built almost entirely on existing infra (anchor #5 — not reinvented):
- `judges/gemini_flash.py` `GeminiFlashJudge.generate()` — existing lazy opt-in Gemini Flash provider, reused for the rewrite call.
- `llm_opt_in.py` flag registry — added a `query_rewrite` flag.
- New `query_rewrite.py` isolates ALL LLM contact.

Activates only when BOTH `COMPASS_PROD_QUERY_REWRITE=1` AND `COMPASS_USE_GEMINI_FLASH=1`.

**Robustness invariant:** any failure (provider off, gemini None/empty/over-long, exception) → returns the ORIGINAL query. Recall is never broken or degraded. Hooked in `daemon.handle_request` for recall actions only, before the P9 cache key.

## Test Plan
- [x] 10 TDD (flag/provider gating, all fallback modes, first-line strip, empty-query identity, flag registered)
- [x] full suite 785 passed (1 pre-existing http_server e2e flake, unrelated)
- [x] ruff clean on changed files; daemon default flag off = no LLM
- [ ] live gemini smoke deferred — needs Vertex SA creds + both flags on; verify by recalling a terse query (e.g. "残保金") with rewrite on and confirming expanded retrieval

## Design
`docs/plans/2026-06-05-gemini-query-rewrite-design.md`