### PR TITLE
feat(fde): Phase A substrate — W6 avoidance corpus + dimension PoI from bus

### DIFF
--- a/docs/plans/2026-06-06-compass-mcp-3agent-dogfood-design.md
+++ b/docs/plans/2026-06-06-compass-mcp-3agent-dogfood-design.md
@@ -1,0 +1,112 @@
+# compass MCP 固化 + 3-agent dogfood — 设计文档 (Phase B · PARKED on G-token)
+
+> **状态:PARKED.** 这是 Phase B 的设计,执行 gated on 平台签发 v5/v7/kairos token +
+> 注册 compass endpoint(G-token)。本文档只定架构+scope+契约,**不 ship 代码**。
+> Phase A(W6 避坑语料 + 维度 PoI from bus + source 过滤)已 ship 并 LIVE 验证(PR #40)。
+
+## 0. 目标
+
+把 compass 从"机械闭环 LIVE"固化成"v5/v7/kairos 三 agent 可稳定消费的记忆/信用/召回
+substrate",接通 dogfood(W6 避坑回喂 + 维度 PoI 自动从 bus 驱动 · 均已建于 Phase A)。
+
+## 1. 架构定调:谁提供什么(已确认 · 回答"是平台提供 MCP+token 吗?")
+
+**不是平台提供 compass 的 MCP 服务。** compass 已自有 MCP 服务 + 鉴权中间件。固化分工:
+
+| 层 | 谁拥有 | 现状(已核实) |
+|---|---|---|
+| MCP 服务 + 工具契约 | **compass**(G-turf) | `mcp_server.py` ~17 工具已建 |
+| **认证 (authn)** | **compass** | `middleware/auth.py` 已建:X-Agent-Key = 平台 JWT(V5_JWT_SECRET 同源)· tenant 派生 quota |
+| **授权 (authz · per-tool scope)** | **compass** | ❌ **缺口** — auth.py 只做 authn + quota + `is_internal` 硬编码 4 agent,**无 per-tool scope 强制** |
+| 跨机传输 (token-gated TCP) | 复用 **v5 已建** | MCP-TCP-auth 已 land(ops/compass-mcp-tcp.service)· 不重造官方 HTTP(7/28 决策) |
+| agent 身份 + token 签发 + 服务注册 | **平台**(身份/经济 hub) | ⏳ G-token:平台给 v5/v7/kairos 各签 token + 公布 endpoint |
+| 稳定部署 (always-on + 监控) | **compass** | 部分(daemon/gateway/tcp systemd)· 待补监控+自重启 |
+
+**结论给用户/平台**:token 鉴权机制 compass 已有(authn)。**Phase B 的真代码缺口 = per-tool
+authz scope 层**(纯 compass turf · un-gated · 可先 TDD)。**平台的角色 = 签 3 个 agent 的
+token + 注册 compass 服务地址**,不需要平台重建 MCP。
+
+## 2. ⚠️ 平台 turf 张力(必读 · 2026-06-06 platform-soul 红线)
+
+platform-soul 收工消息划红线:**「V7/Kairos = V5 turf · 平台只建 substrate」**。
+用户裁决(2026-06-06):**Phase B scope 维持 v5/v7/kairos 三 agent**(否决我"收窄到 v5-only"建议)。
+
+调和:compass **提供** substrate(MCP 服务 + scope),三 agent **消费**。但 kairos/v7 的
+**消费编排**(何时调 compass、调什么)是 V5 turf —— compass 不替它们决策(参 CLAUDE.md
+"不替 agent 决策")。即:compass 给 kairos/v7 各开 scope+token 通道(substrate 层),但
+**不主动 wire kairos/v7 的客户端调用逻辑**;那由 V5/各 agent 框自己接。这条让"维持三 agent
+scope"与"V7/Kairos=V5 turf"并存。
+
+## 3. 三方法案
+
+- **方案 A(推荐)· compass 自建 authz scope 层 + 平台签 token**:compass 在 auth.py 之上加
+  per-tool scope 表(agent_id → 允许的工具集),平台签 token 时把 scope claim 进 JWT 或
+  compass 本地维护 scope 映射。最小新代码 · 复用既有 authn · 守 G-turf。
+- **方案 B · 平台统一 IAM**:平台建中央 IAM 管所有 agent×工具权限,compass 查平台。重 ·
+  违"平台只建 substrate"红线 · 弃。
+- **方案 C · 无 scope · 仅 authn + quota(现状)**:任何持平台 JWT 的 agent 可调任何工具。
+  简单但无最小权限 · 财务/写类工具(ingest/poi)无隔离 · 弃(poi_writer 最小权限先例已立反对)。
+
+**选 A。**
+
+## 4. 设计骨架(方案 A)
+
+### B1 · MCP 工具契约固化(versioned)
+把 `mcp_server.py` ~17 工具冻成 versioned 契约(`/v1/`),分组:
+- **read 组**:recall · drift_check · profile · session_search · drift_history · thread_recall
+- **write 组**:ingest_obs
+- **poi 组**:proof_of_impact(读)· PoI 写限制(poi_writer 最小权限先例 · 只 reconcile/verdict 路写)
+- **governance 组**:governance_dispatch/audit/plan/lock_check(kairos/治理用)
+- **platform 组**:submit_platform_task · ingest_platform_task_result · long_task · add_worker
+- **🆕 维度召回入口**:让 agent 按维度 recall 避坑语料(W6 消费面 · Phase A substrate 的消费 API)
+
+### B2 · 鉴权 + per-agent scope(扩 `middleware/auth.py`)
+现 auth.py 返回 `Tenant`(authn + quota)。**加 scope 强制**:
+- 每 agent 一 token + scope 集(scope 存 compass 本地表 `compass.agent_scopes` 或 JWT claim)
+- **三者通用**:recall / drift_check / profile(read)+ 维度避坑 recall
+- **v5**(nautilus-prime-001 · FDE producer):+ ingest_obs(写 FDE 知识)· W6 避坑 recall 重度
+- **kairos**:+ drift_history / drift_check 重度 + governance_* (V5 turf · compass 只开通道)
+- **v7**:用例待 brainstorming 定(开放决策 · 见 §6)
+- **PoI 写**:全限制(poi_writer secret · 非 MCP 路)
+- 强制点:mcp_server 工具入口查 `tenant.scopes ∋ tool_name` → 否则 403(扩 auth.py 的 Tenant)
+
+### B3 · 跨机传输(复用 v5 token-gated TCP)
+compass MCP 走 v5 已建 token-gated TCP(跨机)+ stdio(同机)· 不造官方 HTTP。
+
+### B4 · 稳定部署
+compass MCP/daemon/gateway/tcp 作 cloud systemd 服务(已部分)· 补 always-on 监控 + 自重启
++ 状态端点。
+
+### B5 · 平台侧(跨框 · G-token · 给平台对话框)
+- 平台签 v5/v7/kairos 三 token(scope claim 或仅身份 · compass 本地映射 scope)
+- 平台注册 compass MCP endpoint 到服务发现
+- 三 agent 各自 wire MCP client 连 compass(带 token)· kairos/v7 的 wire 是各框 turf
+
+### B6 · dogfood 验收锚
+每 agent 至少一条 recall + 一条 ingest 实测通:
+- **v5**:solve_task 前 recall `fde-dim-<维度>` 避坑(W6 消费)→ 注入约束 → pass 率升(对比基线)
+- **kairos**:drift_check / drift_history 查询实测
+- **v7**:用例定后实测
+
+## 5. gated 边界
+
+- **G-token**(整个 Phase B 执行):平台签 v5/v7/kairos token + 注册 endpoint。
+- **G-rsi**:W6 反馈环 live wire(v5 真在 solve_task 前 recall)等平台 data_002→003 grounding 证实。
+- **G-expert**:真飞轮燃料 = 真人专家飞书复核(用户安排 · compass 出复核包)· 非 Phase B 代码。
+
+## 6. 开放决策(需 brainstorming / 用户 / 平台)
+
+1. **v7 的 dogfood 用例未定**(plan 标"待定")。v7 是什么 agent?消费 compass 什么?→ 需 V5/用户定。
+2. **scope 存哪**:JWT claim(平台签时塞)vs compass 本地表(compass 自管)。倾向本地表(G-turf ·
+   平台只签身份不管权限)· 但需平台 token 带稳定 agent_id。
+3. **kairos/v7 消费编排归属**:确认 compass 只开 substrate 通道,不 wire 它们的调用逻辑(§2 张力)。
+
+## 7. 可先做的 un-gated 切片(若用户改主意要 ship)
+
+§4 B2 的 **per-tool authz scope 层是纯 compass turf · 不需平台 token 即可 TDD ship**:
+先建 `compass.agent_scopes` + auth.py 的 scope 强制 + 工具入口 403 守卫,用 mock token 测。
+平台签 token 后只需把真 agent_id 填进 scope 表即生效。但用户本轮选"只出设计文档 parked",故不 ship。
+
+## 关联
+[[reference_compass_rsi_fde_role_progress]] · [[session_20260606_fde_dimension_poi_closure]] ·
+既有 `mcp_server.py` / `middleware/auth.py` · v5 MCP-TCP-auth · 2026-06-06-compass-substrate-solidification.md(Phase A)

--- a/ops/fde_avoidance_corpus_build.py
+++ b/ops/fde_avoidance_corpus_build.py
@@ -1,0 +1,199 @@
+"""compass · FDE avoidance-corpus batch build driver (W6 substrate · Task A1).
+
+Turns every real FDE verdict+checklist pair into recallable per-RUBRIC-dimension
+avoid-pitfall (失败 item) / proven-approach (通过 item) knowledge atoms that
+accumulate across tasks. This is the W6 substrate: before solving the next buyer
+task v5's copilot recalls `fde-dim-<dimension>` and is grounded by every prior
+task's mistakes on that dimension — the dogfood loop that turns external buyer
+verdicts into compounding capability (anchor #1 agent-first).
+
+Two seams (so compass core stays decoupled from the vtf capsule module — design §3):
+  · load_fde_tasks — pure on-disk loader (picks the LATEST verdict per task; a
+    rescored verdict supersedes its predecessor; UTF-8 — the files are CJK).
+  · build_corpus — feeds the (injected) vtf capsule callables through the existing
+    proof.fde_batch_ingest flywheel (atoms accumulate + dimensions earn PoI).
+
+main() resolves the vtf toolbox (sibling repo or $COMPASS_VTF_DIR) and wires
+fde_knowledge_capsule.{build_dimension_atoms, ingest_atoms, map_to_rubric_dimension}.
+NO LLM (the dimension mapper is deterministic keyword). Material only fingerprinted.
+
+Run:
+  python ops/fde_avoidance_corpus_build.py            # build atoms into the fde-knowledge memory dir
+  python ops/fde_avoidance_corpus_build.py --dry-run  # load + report tasks, write nothing
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import importlib.util
+import json
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+from proof.fde_batch_ingest import batch_ingest_and_credit  # noqa: E402
+from proof.fde_poi_adapter import DEFAULT_DIM_PROJECT  # noqa: E402
+
+# `_v5_<something>_real_verdict_<YYYYMMDD>.json` — the date suffix orders rescored
+# verdicts (a higher date wins). The authoritative task_uid is read from the file,
+# not parsed from the name (the name uses `data003`, the uid is `data_002`-style).
+_VERDICT_GLOB = "_v5_*_real_verdict_*.json"
+_DATE_RE = re.compile(r"_(\d{8})\.json$")
+# `_v5_<token>_real_verdict_<date>.json` → <token> (e.g. `data001`)
+_TOKEN_RE = re.compile(r"^_v5_(.+?)_real_verdict_\d{8}\.json$")
+# normalize a filename token `data001` → canonical uid `data_001` (alpha_numeric)
+_UID_NORM_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
+
+
+def _read_json(path: str) -> dict:
+    """UTF-8 read (the FDE files are CJK; the Windows gbk default crashes)."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _verdict_date(path: str) -> str:
+    """Sort key for picking the latest verdict — the YYYYMMDD filename suffix, or
+    '' so an undated file never beats a dated rescore."""
+    m = _DATE_RE.search(os.path.basename(path))
+    return m.group(1) if m else ""
+
+
+def _uid_from_filename(path: str) -> str:
+    """Fallback task_uid when the verdict JSON omits the field (real case:
+    data_001's verdict carries answer_len, not task_uid). Extract the filename
+    token and normalize `data001` → `data_001` so it joins the checklist key."""
+    m = _TOKEN_RE.match(os.path.basename(path))
+    if not m:
+        return ""
+    token = m.group(1)
+    nm = _UID_NORM_RE.match(token)
+    return f"{nm.group(1)}_{nm.group(2)}" if nm else token
+
+
+def load_fde_tasks(verdict_dir, checklist_dir, task_ids=None):
+    """Discover {task_id, checklist, verdict} tuples from disk.
+
+    For each verdict file (`_v5_*_real_verdict_*.json`) the task_uid is read from
+    the file; the LATEST verdict per task_uid wins (by YYYYMMDD filename suffix).
+    The matching `<task_uid>_checklist.json` is loaded from checklist_dir; a task
+    whose checklist is missing is skipped (warned to stderr). Optionally filtered
+    to `task_ids`. Returns the list sorted by task_id."""
+    latest: dict = {}  # task_uid -> (date, verdict, path)
+    for path in glob.glob(os.path.join(verdict_dir, _VERDICT_GLOB)):
+        try:
+            verdict = _read_json(path)
+        except (OSError, ValueError) as e:
+            print(f"[corpus] skip unreadable verdict {path}: {e}", file=sys.stderr)
+            continue
+        uid = str(verdict.get("task_uid") or "").strip() or _uid_from_filename(path)
+        if not uid:
+            print(f"[corpus] skip verdict without task_uid: {path}", file=sys.stderr)
+            continue
+        date = _verdict_date(path)
+        if uid not in latest or date > latest[uid][0]:
+            latest[uid] = (date, verdict, path)
+
+    tasks = []
+    for uid, (_date, verdict, _path) in latest.items():
+        if task_ids is not None and uid not in task_ids:
+            continue
+        cl_path = os.path.join(checklist_dir, f"{uid}_checklist.json")
+        if not os.path.exists(cl_path):
+            print(f"[corpus] skip {uid}: no checklist at {cl_path}", file=sys.stderr)
+            continue
+        try:
+            checklist = _read_json(cl_path)
+        except (OSError, ValueError) as e:
+            print(f"[corpus] skip {uid}: unreadable checklist {cl_path}: {e}", file=sys.stderr)
+            continue
+        tasks.append({"task_id": uid, "checklist": checklist, "verdict": verdict})
+
+    return sorted(tasks, key=lambda t: t["task_id"])
+
+
+def build_corpus(tasks, mem_dir, conn, now_iso, *, build_atoms, ingest_atoms,
+                 dimension_for, placeholder="?", project=DEFAULT_DIM_PROJECT,
+                 pass_score=None):
+    """Run the dimension flywheel over `tasks`: accumulate avoidance atoms into
+    `mem_dir` (one `fde-dim-<dimension>.md` per dimension) and credit per-dimension
+    PoI into `conn`. The vtf capsule callables are injected (compass core never
+    imports vtf). Delegates to proof.fde_batch_ingest.batch_ingest_and_credit;
+    returns its {per_task, credit_snapshot, dimension_events, atom_paths}."""
+    return batch_ingest_and_credit(
+        conn, tasks, now_iso, placeholder,
+        dimension_for=dimension_for, build_atoms=build_atoms,
+        ingest_atoms=ingest_atoms, mem_dir=mem_dir, project=project,
+        pass_score=pass_score)
+
+
+# ─── main() · resolve vtf + wire ─────────────────────────────────────────────
+
+def _resolve_vtf():
+    """Locate the vtf fde-toolbox (env override or sibling repo) and return its
+    capsule callables. main()-only; the unit tests inject stubs instead."""
+    candidates = []
+    env = os.environ.get("COMPASS_VTF_DIR")
+    if env:
+        candidates.append(Path(env))
+    candidates.append(_HERE.parent.parent / "vertical-task-factory" / "fde-toolbox")
+    for c in candidates:
+        if (c / "fde_knowledge_capsule.py").exists():
+            spec = importlib.util.spec_from_file_location(
+                "fde_knowledge_capsule", c / "fde_knowledge_capsule.py")
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod, c
+    raise SystemExit(
+        "[corpus] vtf fde-toolbox not found — set COMPASS_VTF_DIR to the dir "
+        "containing fde_knowledge_capsule.py")
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Build the FDE avoidance corpus (W6 substrate).")
+    ap.add_argument("--verdict-dir", help="dir with _v5_*_real_verdict_*.json (default: vtf root)")
+    ap.add_argument("--checklist-dir", help="dir with <uid>_checklist.json (default: vtf root)")
+    ap.add_argument("--mem-dir", help="atoms output dir (default: ~/.claude/projects/fde-knowledge/memory)")
+    ap.add_argument("--credit-db", help="sqlite path for dimension PoI (default: in-memory)")
+    ap.add_argument("--dry-run", action="store_true", help="load + report tasks, write nothing")
+    args = ap.parse_args(argv)
+
+    mod, vtf_dir = _resolve_vtf()
+    verdict_dir = args.verdict_dir or str(vtf_dir.parent)
+    checklist_dir = args.checklist_dir or str(vtf_dir.parent)
+    mem_dir = args.mem_dir or os.path.expanduser(
+        "~/.claude/projects/fde-knowledge/memory")
+    now_iso = os.environ.get("COMPASS_CORPUS_NOW") or _utc_now()
+
+    tasks = load_fde_tasks(verdict_dir, checklist_dir)
+    print(f"[corpus] loaded {len(tasks)} tasks: {[t['task_id'] for t in tasks]}")
+    if args.dry_run:
+        return 0
+
+    conn = sqlite3.connect(args.credit_db or ":memory:")
+    conn.execute("CREATE TABLE IF NOT EXISTS poi_credit (memory_key TEXT PRIMARY KEY, "
+                 "cumulative_impact REAL NOT NULL DEFAULT 0, "
+                 "event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+    conn.commit()
+
+    res = build_corpus(
+        tasks, mem_dir, conn, now_iso,
+        build_atoms=mod.build_dimension_atoms, ingest_atoms=mod.ingest_atoms,
+        dimension_for=mod.map_to_rubric_dimension)
+    print(f"[corpus] dimensions: {res['dimension_events']}")
+    print(f"[corpus] atom files: {len(res['atom_paths'])} → {mem_dir}")
+    for dim, p in sorted(res["atom_paths"].items()):
+        print(f"  · {dim}: {p}")
+    return 0
+
+
+def _utc_now():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ops/fde_verdict_reconcile.py
+++ b/ops/fde_verdict_reconcile.py
@@ -65,8 +65,46 @@ def save_since(path, last_created_at) -> None:
                  encoding="utf-8")
 
 
+def settle_once(conn, since, checklist_dir, placeholder="%s", dimension_for=None,
+                project=BUS.DEFAULT_DIM_PROJECT):
+    """One settle pass over the bus: task-level spine (fde-capsule-<uid>) AND —
+    when `checklist_dir` is given — dimension-level PoI (fde-dim-<dim> joined to
+    local checklists), both over the SAME `since` watermark. The task spine is the
+    authoritative watermark (it reads every row; a missing checklist only skips
+    that row's dimension credit, never the spine). Returns {task, dimension,
+    last_created_at}."""
+    task = BUS.from_fde_verdicts(conn, conn, since=since, placeholder=placeholder)
+    if checklist_dir:
+        dimension = BUS.credit_dimensions_from_bus(
+            conn, conn, checklist_dir, since=since, placeholder=placeholder,
+            dimension_for=dimension_for, project=project)
+    else:
+        dimension = {"processed": 0, "credited": [], "skipped_no_checklist": [],
+                     "last_created_at": since}
+    return {"task": task, "dimension": dimension,
+            "last_created_at": task["last_created_at"]}
+
+
+def _resolve_dimension_for():
+    """Best-effort vtf RUBRIC mapper for dimension granularity. Returns None
+    (adapter falls back to its generic mapper) when vtf is not co-located — the
+    dimension credit then degrades gracefully instead of failing."""
+    vtf = os.environ.get("COMPASS_VTF_DIR")
+    candidates = [Path(vtf)] if vtf else []
+    candidates.append(_HERE.parent.parent / "vertical-task-factory" / "fde-toolbox")
+    for c in candidates:
+        cap = c / "fde_knowledge_capsule.py"
+        if cap.exists():
+            spec = importlib.util.spec_from_file_location("fde_knowledge_capsule", cap)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod.map_to_rubric_dimension
+    return None
+
+
 def main() -> int:
     dry_run = "--dry-run" in sys.argv
+    checklist_dir = os.environ.get("COMPASS_FDE_CHECKLIST_DIR")
     stamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
     try:
@@ -87,9 +125,11 @@ def main() -> int:
                 print(f"{stamp} · DRY-RUN · would settle {len(rows)} verdict(s) "
                       f"since={since}: {[r['task_uid'] for r in rows]}")
                 return 0
-            res = BUS.from_fde_verdicts(conn, conn, since=since, placeholder="%s")
+            combined = settle_once(conn, since, checklist_dir, placeholder="%s",
+                                   dimension_for=_resolve_dimension_for())
+            res = combined["task"]
             if res["processed"]:
-                save_since(WATERMARK_PATH, res["last_created_at"])
+                save_since(WATERMARK_PATH, combined["last_created_at"])
                 CS.write_snapshot_atomic(SNAPSHOT_PATH, CS.fetch_all_credits(conn))
     except (FileNotFoundError, ValueError, RuntimeError) as e:
         # tunnel/secret/connect failure → honest skip (gated, not a hard error)
@@ -101,9 +141,11 @@ def main() -> int:
                          f"{str(e)[:200]} · (likely G-cloud: table/GRANT pending)\n")
         return 0
 
+    dim = combined["dimension"]
     print(f"{stamp} · fde verdicts processed={res['processed']} since={since} "
-          f"-> {res['last_created_at']} · credited="
-          f"{[(c['task_uid'], c['delta']) for c in res['credited']]}")
+          f"-> {combined['last_created_at']} · task_credited="
+          f"{[(c['task_uid'], c['delta']) for c in res['credited']]} · "
+          f"dim_processed={dim['processed']} dim_skipped={dim['skipped_no_checklist']}")
     return 0
 
 

--- a/proof/fde_verdict_bus_reader.py
+++ b/proof/fde_verdict_bus_reader.py
@@ -19,8 +19,12 @@ local checklist+verdict pair. This reader is the task-level spine.
 from __future__ import annotations
 
 import json
+import os
+import sys
 
-from .fde_poi_adapter import credit_from_checklist_verdict
+from .fde_poi_adapter import (
+    DEFAULT_DIM_PROJECT, credit_dimensions_from_verdict,
+    credit_from_checklist_verdict)
 
 # contract columns compass depends on (drift-guarded platform-side by
 # tests/test_fde_verdict_contract.py)
@@ -101,4 +105,74 @@ def from_fde_verdicts(bus_conn, credit_conn, since=None, placeholder="%s",
         last_created_at = created_at
 
     return {"processed": len(rows), "credited": credited,
+            "last_created_at": last_created_at}
+
+
+def _load_local_checklist(checklist_dir, task_uid):
+    """Read `<checklist_dir>/<task_uid>_checklist.json` (UTF-8 · the files are
+    CJK). Returns the checklist dict, or None when absent/unreadable so the caller
+    can skip the dimension credit without stalling the verdict stream."""
+    path = os.path.join(checklist_dir, f"{task_uid}_checklist.json")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"[bus] unreadable checklist {path}: {e}", file=sys.stderr)
+        return None
+
+
+def credit_dimensions_from_bus(bus_conn, credit_conn, checklist_dir, since=None,
+                               placeholder="%s", dimension_for=None,
+                               project=DEFAULT_DIM_PROJECT, pass_score=None):
+    """Credit DIMENSION-level PoI from the verdict-bus (Option C · design §45).
+
+    The bus row carries the verdict items but not the checklist content (only
+    checklist_uid), so dimension granularity needs the checklist. This joins each
+    bus verdict to its LOCAL `<task_uid>_checklist.json` by task_uid and runs the
+    existing credit_dimensions_from_verdict (passed item → +score on its mapped
+    dimension key; failed item → 0). A verdict whose local checklist is missing is
+    skipped for dimension crediting (recorded · the task-level spine
+    `from_fde_verdicts` still covers it) but the watermark still advances so a
+    missing checklist never stalls the stream. `dimension_for` is injected (compass
+    core stays decoupled from vtf); production wires map_to_rubric_dimension.
+
+    `since` is an exclusive created_at watermark. Returns {processed,
+    credited:[{task_uid, verdict_id, credited:{dim:delta}, events}],
+    skipped_no_checklist:[task_uid...], last_created_at}."""
+    sql = _SELECT
+    params: tuple = ()
+    if since is not None:
+        sql += f" WHERE created_at > {placeholder}"
+        params = (since,)
+    sql += " ORDER BY created_at ASC"
+
+    cur = bus_conn.cursor()
+    cur.execute(sql, params)
+    rows = cur.fetchall()
+
+    credited = []
+    skipped_no_checklist = []
+    last_created_at = since
+    for verdict_id, task_uid, overall_pass, veto_failed, score, items, created_at in rows:
+        last_created_at = created_at
+        checklist = _load_local_checklist(checklist_dir, task_uid)
+        if checklist is None:
+            skipped_no_checklist.append(task_uid)
+            continue
+        verdict = {
+            "overall_pass": bool(overall_pass),
+            "veto_failed": bool(veto_failed),
+            "score": float(score),
+            "items": _coerce_items(items),
+        }
+        summary = credit_dimensions_from_verdict(
+            credit_conn, task_uid, checklist, verdict, created_at, placeholder,
+            dimension_for=dimension_for, pass_score=pass_score, project=project)
+        credited.append({"task_uid": task_uid, "verdict_id": verdict_id,
+                         "credited": summary["credited"], "events": summary["events"]})
+
+    return {"processed": len(rows), "credited": credited,
+            "skipped_no_checklist": skipped_no_checklist,
             "last_created_at": last_created_at}

--- a/proof/fde_verdict_bus_reader.py
+++ b/proof/fde_verdict_bus_reader.py
@@ -31,6 +31,41 @@ from .fde_poi_adapter import (
 _SELECT = ("SELECT verdict_id, task_uid, overall_pass, veto_failed, score, "
            "items, created_at FROM fde_verdicts")
 
+# Authoritative PoI fitness sources (allowlist). The 一审 soul checklist verdict
+# is the ONLY PoI source; from 2026-06-06 V5 also writes a Kairos Opus adversarial
+# 二审 as source='kairos-opus' — settling that double-counts the same task's PoI,
+# so it MUST be excluded.
+#
+# Tag reality (verified against production fde_verdicts 2026-06-06): the live 一审
+# rows are tagged source='fde-capsule-v5' (V5 relays soul's checklist_scorer
+# verdict), NOT 'soul' as the platform's WHERE source='soul' request literally
+# stated — an allowlist of just 'soul' would settle NOTHING and break the live
+# loop. So this allows BOTH the real live tag and 'soul' (in case the platform
+# re-tags the 一审 to 'soul' later); either settles, kairos-opus never does.
+# Append the 真人专家 (expert) source HERE when that 飞书 review path lands
+# (anchor #3 north-star fuel). Reverses the original rule A "don't filter source"
+# (FDE_VERDICT_BUS_CONTRACT.md) at the platform's request.
+SETTLE_SOURCES = ("fde-capsule-v5", "soul")
+
+
+def _where_and_params(since, sources, placeholder):
+    """Build the shared `WHERE source IN (...) AND created_at > since` clause +
+    ordered params. `sources=None` reads every source (audit). Empty sources →
+    a clause that matches nothing (never settle when no source is authoritative)."""
+    clauses = []
+    params: list = []
+    if sources is not None:
+        if not sources:
+            return " WHERE 1=0", ()
+        marks = ",".join([placeholder] * len(sources))
+        clauses.append(f"source IN ({marks})")
+        params.extend(sources)
+    if since is not None:
+        clauses.append(f"created_at > {placeholder}")
+        params.append(since)
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    return where, tuple(params)
+
 
 def _coerce_items(raw):
     """Bus `items` is JSONB (psycopg2 → list) in prod, json TEXT in the sqlite
@@ -44,20 +79,16 @@ def _coerce_items(raw):
         return []
 
 
-def peek_fde_verdicts(bus_conn, since=None, placeholder="%s"):
-    """Read-only dry-run · list the verdicts that WOULD settle (created_at >
-    since, ascending) WITHOUT crediting anything. Lets a caller verify the GRANT
-    SELECT is live on a strictly read-only connection before any write.
+def peek_fde_verdicts(bus_conn, since=None, placeholder="%s", sources=SETTLE_SOURCES):
+    """Read-only dry-run · list the verdicts that WOULD settle (settling sources,
+    created_at > since, ascending) WITHOUT crediting anything. Lets a caller verify
+    the GRANT SELECT is live on a strictly read-only connection before any write.
 
     Returns [{verdict_id, task_uid, overall_pass, veto_failed, score,
     created_at}]."""
+    where, params = _where_and_params(since, sources, placeholder)
     sql = ("SELECT verdict_id, task_uid, overall_pass, veto_failed, score, "
-           "created_at FROM fde_verdicts")
-    params: tuple = ()
-    if since is not None:
-        sql += f" WHERE created_at > {placeholder}"
-        params = (since,)
-    sql += " ORDER BY created_at ASC"
+           "created_at FROM fde_verdicts" + where + " ORDER BY created_at ASC")
     cur = bus_conn.cursor()
     cur.execute(sql, params)
     return [{"verdict_id": r[0], "task_uid": r[1], "overall_pass": bool(r[2]),
@@ -66,7 +97,7 @@ def peek_fde_verdicts(bus_conn, since=None, placeholder="%s"):
 
 
 def from_fde_verdicts(bus_conn, credit_conn, since=None, placeholder="%s",
-                      reject_delta=None):
+                      reject_delta=None, sources=SETTLE_SOURCES):
     """Read `fde_verdicts` rows (created_at > since, ascending) and credit
     task-level PoI for each into credit_conn's poi_credit table.
 
@@ -77,12 +108,8 @@ def from_fde_verdicts(bus_conn, credit_conn, since=None, placeholder="%s",
 
     Returns {processed, credited:[{task_uid, verdict_id, delta, action_outcome}],
     last_created_at}."""
-    sql = _SELECT
-    params: tuple = ()
-    if since is not None:
-        sql += f" WHERE created_at > {placeholder}"
-        params = (since,)
-    sql += " ORDER BY created_at ASC"
+    where, params = _where_and_params(since, sources, placeholder)
+    sql = _SELECT + where + " ORDER BY created_at ASC"
 
     cur = bus_conn.cursor()
     cur.execute(sql, params)
@@ -125,7 +152,8 @@ def _load_local_checklist(checklist_dir, task_uid):
 
 def credit_dimensions_from_bus(bus_conn, credit_conn, checklist_dir, since=None,
                                placeholder="%s", dimension_for=None,
-                               project=DEFAULT_DIM_PROJECT, pass_score=None):
+                               project=DEFAULT_DIM_PROJECT, pass_score=None,
+                               sources=SETTLE_SOURCES):
     """Credit DIMENSION-level PoI from the verdict-bus (Option C · design §45).
 
     The bus row carries the verdict items but not the checklist content (only
@@ -141,12 +169,8 @@ def credit_dimensions_from_bus(bus_conn, credit_conn, checklist_dir, since=None,
     `since` is an exclusive created_at watermark. Returns {processed,
     credited:[{task_uid, verdict_id, credited:{dim:delta}, events}],
     skipped_no_checklist:[task_uid...], last_created_at}."""
-    sql = _SELECT
-    params: tuple = ()
-    if since is not None:
-        sql += f" WHERE created_at > {placeholder}"
-        params = (since,)
-    sql += " ORDER BY created_at ASC"
+    where, params = _where_and_params(since, sources, placeholder)
+    sql = _SELECT + where + " ORDER BY created_at ASC"
 
     cur = bus_conn.cursor()
     cur.execute(sql, params)

--- a/tests/test_fde_avoidance_corpus.py
+++ b/tests/test_fde_avoidance_corpus.py
@@ -1,0 +1,174 @@
+"""Task A1 · batch avoidance-corpus build driver (W6 substrate).
+
+`ops/fde_avoidance_corpus_build` is the glue that turns all the real FDE
+verdict+checklist pairs into recallable per-dimension avoid-pitfall / proven
+knowledge atoms (the W6 substrate v5's copilot recalls before solving the next
+task). The driver owns two seams:
+
+  · load_fde_tasks — discover {task_id, checklist, verdict} from the on-disk
+    `_v5_<uid>_real_verdict_<date>.json` + `<uid>_checklist.json` files, picking
+    the LATEST verdict per task (a rescored verdict supersedes its predecessor),
+    UTF-8 (the files are CJK — gbk default would crash on Windows).
+  · build_corpus — wire the (injected) vtf capsule callables into the existing
+    proof.fde_batch_ingest pipeline so atoms accumulate + dimensions get PoI.
+
+The vtf atom FORMAT (避坑/亮点 marker) is tested by vtf's own suite; here we test
+the DRIVER contract (loading + wiring) with stubs so CI stays compass-only. NO LLM.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN))
+from ops import fde_avoidance_corpus_build as drv  # noqa: E402
+
+NOW = "2026-06-06T12:00:00Z"
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.write_text(json.dumps(obj, ensure_ascii=False), encoding="utf-8")
+
+
+def _verdict(task_uid, items, score=1.0):
+    return {"task_uid": task_uid, "score": score, "passed": sum(1 for i in items if i["pass"]),
+            "total": len(items), "veto_failed": False,
+            "overall_pass": all(i["pass"] for i in items), "items": items}
+
+
+def _checklist(task_uid, items):
+    return {"task_uid": task_uid, "items": items}
+
+
+def _mk_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, "
+                 "cumulative_impact REAL NOT NULL DEFAULT 0, "
+                 "event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+    conn.commit()
+    return conn
+
+
+# ── RED 1 · loader picks the LATEST verdict per task ─────────────────────────
+def test_load_picks_latest_verdict_per_task(tmp_path):
+    vdir = tmp_path / "v"; cdir = tmp_path / "c"
+    vdir.mkdir(); cdir.mkdir()
+    # data_003 has two verdicts: an older one and a rescored newer one
+    _write(vdir / "_v5_data003_real_verdict_20260605.json",
+           _verdict("data_003", [{"id": "c1", "pass": False, "reason": "old"}], score=0.3))
+    _write(vdir / "_v5_data003_real_verdict_20260606.json",
+           _verdict("data_003", [{"id": "c1", "pass": True, "reason": "rescored"}], score=0.9))
+    _write(cdir / "data_003_checklist.json",
+           _checklist("data_003", [{"id": "c1", "point": "p", "dimension": "calc-formula"}]))
+
+    tasks = drv.load_fde_tasks(str(vdir), str(cdir))
+
+    assert len(tasks) == 1
+    t = tasks[0]
+    assert t["task_id"] == "data_003"
+    # the rescored (20260606) verdict wins
+    assert t["verdict"]["score"] == 0.9
+    assert t["verdict"]["items"][0]["reason"] == "rescored"
+
+
+# ── RED 2 · loader reads UTF-8 CJK + joins checklist by task_uid ──────────────
+def test_load_reads_utf8_and_joins_checklist(tmp_path):
+    vdir = tmp_path / "v"; cdir = tmp_path / "c"
+    vdir.mkdir(); cdir.mkdir()
+    _write(vdir / "_v5_data002_real_verdict_20260605.json",
+           _verdict("data_002", [{"id": "c4", "pass": False, "reason": "隐私红线被突破·避坑"}]))
+    _write(cdir / "data_002_checklist.json",
+           _checklist("data_002", [{"id": "c4", "point": "匿名化处理", "dimension": "task-specific"}]))
+
+    tasks = drv.load_fde_tasks(str(vdir), str(cdir))
+
+    assert tasks[0]["task_id"] == "data_002"
+    assert tasks[0]["verdict"]["items"][0]["reason"] == "隐私红线被突破·避坑"
+    assert tasks[0]["checklist"]["items"][0]["point"] == "匿名化处理"
+
+
+# ── RED 3 · a verdict with no matching checklist is skipped (warned) ─────────
+def test_load_skips_task_without_checklist(tmp_path):
+    vdir = tmp_path / "v"; cdir = tmp_path / "c"
+    vdir.mkdir(); cdir.mkdir()
+    _write(vdir / "_v5_data009_real_verdict_20260605.json",
+           _verdict("data_009", [{"id": "c1", "pass": True, "reason": "ok"}]))
+    # no data_009_checklist.json
+
+    tasks = drv.load_fde_tasks(str(vdir), str(cdir))
+    assert tasks == []
+
+
+# ── RED 3b · task_uid absent in verdict → derive from filename token ─────────
+# (real data: data_001's verdict carries answer_len, not task_uid; the filename
+# token `data001` must normalize to the canonical `data_001` checklist key)
+def test_load_derives_task_uid_from_filename_when_absent(tmp_path):
+    vdir = tmp_path / "v"; cdir = tmp_path / "c"
+    vdir.mkdir(); cdir.mkdir()
+    v = _verdict("data_001", [{"id": "c1", "pass": True, "reason": "ok"}])
+    del v["task_uid"]  # mimic data_001's real shape (no task_uid)
+    _write(vdir / "_v5_data001_real_verdict_20260605.json", v)
+    _write(cdir / "data_001_checklist.json",
+           _checklist("data_001", [{"id": "c1", "point": "p", "dimension": "coverage"}]))
+
+    tasks = drv.load_fde_tasks(str(vdir), str(cdir))
+    assert len(tasks) == 1
+    assert tasks[0]["task_id"] == "data_001"
+
+
+# ── RED 4 · build_corpus feeds each task through atoms + credits dimensions ──
+def test_build_corpus_feeds_each_task_and_credits_dimensions(tmp_path):
+    conn = _mk_db()
+    mem_dir = str(tmp_path / "mem")
+
+    tasks = [
+        {"task_id": "data_001",
+         "checklist": _checklist("data_001", [
+             {"id": "c1", "point": "用公式测算", "dimension": "calc-formula"},
+             {"id": "c4", "point": "匿名化", "dimension": "hallucination-control"}]),
+         "verdict": _verdict("data_001", [
+             {"id": "c1", "pass": True, "reason": "公式正确"},
+             {"id": "c4", "pass": False, "reason": "泄露隐私·避坑"}], score=0.9)},
+    ]
+
+    seen_build = []
+    seen_ingest = []
+
+    def stub_build(task_id, checklist, verdict):
+        seen_build.append(task_id)
+        # mimic vtf: one atom per scored item, fail → avoidance
+        return [{"dimension": it["dimension"], "checklist_id": it["id"],
+                 "passed": vi["pass"], "knowledge": vi["reason"]}
+                for it, vi in zip(checklist["items"], verdict["items"])]
+
+    def stub_ingest(atoms, md):
+        seen_ingest.append(atoms)
+        return {a["dimension"]: f"{md}/fde-dim-{a['dimension']}.md" for a in atoms}
+
+    def stub_dim(item):
+        return item["dimension"]
+
+    res = drv.build_corpus(tasks, mem_dir, conn, NOW, build_atoms=stub_build,
+                           ingest_atoms=stub_ingest, dimension_for=stub_dim,
+                           placeholder="?")
+
+    # each task fed through both vtf seams
+    assert seen_build == ["data_001"]
+    assert len(seen_ingest) == 1
+    # the failed item (c4) IS present in the atoms handed to ingest (avoidance kept)
+    fail_atoms = [a for batch in seen_ingest for a in batch if not a["passed"]]
+    assert any(a["checklist_id"] == "c4" for a in fail_atoms)
+    # passed dimension credited; failed dimension NOT credited (0, only capsule kept)
+    from proof import fde_poi_adapter as adp
+
+    def dim_credit(dim):
+        return conn.execute("SELECT cumulative_impact FROM poi_credit WHERE memory_key=?",
+                            (adp.dimension_memory_key(dim),)).fetchone()
+
+    assert dim_credit("calc-formula") is not None
+    assert dim_credit("hallucination-control") is None
+    # result surfaces accumulated atom paths
+    assert "calc-formula" in res["atom_paths"]

--- a/tests/test_fde_verdict_bus_dimension.py
+++ b/tests/test_fde_verdict_bus_dimension.py
@@ -1,0 +1,146 @@
+"""Task A2 · dimension-level PoI auto-driven from the verdict-bus (Option C).
+
+The bus row carries the verdict items (id + pass) but NOT the checklist content
+(only checklist_uid) — so dimension granularity needs the checklist. Option C
+joins each bus verdict to its LOCAL `<task_uid>_checklist.json` by task_uid and
+runs the existing credit_dimensions_from_verdict. No cross-framework change: both
+halves (bus verdict + local checklist) already live in compass. NO LLM.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN))
+from proof import fde_poi_adapter as adp  # noqa: E402
+from proof import fde_verdict_bus_reader as bus  # noqa: E402
+
+
+def _mk_bus():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE fde_verdicts (id INTEGER PRIMARY KEY, "
+        "verdict_id TEXT UNIQUE NOT NULL, task_uid TEXT NOT NULL, source TEXT NOT NULL, "
+        "checklist_uid TEXT, overall_pass INTEGER NOT NULL, veto_failed INTEGER NOT NULL, "
+        "score REAL NOT NULL, items TEXT NOT NULL DEFAULT '[]', artifacts TEXT, "
+        "created_at TEXT NOT NULL)")
+    conn.commit()
+    return conn
+
+
+def _ins(conn, verdict_id, task_uid, overall_pass, veto_failed, score, items, created_at):
+    conn.execute(
+        "INSERT INTO fde_verdicts (verdict_id, task_uid, source, overall_pass, "
+        "veto_failed, score, items, created_at) VALUES (?,?,?,?,?,?,?,?)",
+        (verdict_id, task_uid, "v5", int(overall_pass), int(veto_failed), score,
+         json.dumps(items), created_at))
+    conn.commit()
+
+
+def _mk_credit():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, "
+                 "cumulative_impact REAL NOT NULL DEFAULT 0, "
+                 "event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+    conn.commit()
+    return conn
+
+
+def _dim(conn, dim):
+    return conn.execute("SELECT cumulative_impact, event_count FROM poi_credit "
+                        "WHERE memory_key=?", (adp.dimension_memory_key(dim),)).fetchone()
+
+
+def _write_checklist(cdir: Path, task_uid: str, items: list):
+    (cdir / f"{task_uid}_checklist.json").write_text(
+        json.dumps({"task_uid": task_uid, "items": items}, ensure_ascii=False),
+        encoding="utf-8")
+
+
+def _stub_dim(item):
+    return item.get("dimension", "coverage")
+
+
+# ── RED 1 · bus verdict joined to local checklist → dimension PoI ────────────
+def test_credits_dimensions_from_bus_joined_to_local_checklist(tmp_path):
+    busc = _mk_bus()
+    _ins(busc, "v-1", "data_001", True, False, 0.9,
+         [{"id": "c1", "pass": True}, {"id": "c2", "pass": True}],
+         "2026-06-05T02:47:00Z")
+    cdir = tmp_path / "cl"; cdir.mkdir()
+    _write_checklist(cdir, "data_001", [
+        {"id": "c1", "point": "公式测算", "dimension": "calc-formula"},
+        {"id": "c2", "point": "用附件", "dimension": "attachment-use"}])
+    creditc = _mk_credit()
+
+    res = bus.credit_dimensions_from_bus(
+        busc, creditc, str(cdir), placeholder="?", dimension_for=_stub_dim)
+
+    assert res["processed"] == 1
+    assert _dim(creditc, "calc-formula") == pytest.approx((0.9, 1))
+    assert _dim(creditc, "attachment-use") == pytest.approx((0.9, 1))
+    assert res["last_created_at"] == "2026-06-05T02:47:00Z"
+
+
+# ── RED 2 · a verdict with no local checklist is skipped (recorded) ──────────
+def test_skips_task_without_local_checklist(tmp_path):
+    busc = _mk_bus()
+    _ins(busc, "v-9", "data_099", True, False, 1.0,
+         [{"id": "c1", "pass": True}], "2026-06-05T03:00:00Z")
+    cdir = tmp_path / "cl"; cdir.mkdir()  # no data_099_checklist.json
+    creditc = _mk_credit()
+
+    res = bus.credit_dimensions_from_bus(
+        busc, creditc, str(cdir), placeholder="?", dimension_for=_stub_dim)
+
+    assert res["processed"] == 1
+    assert res["skipped_no_checklist"] == ["data_099"]
+    assert _dim(creditc, "coverage") is None  # nothing credited
+    # watermark still advances so a missing checklist does not stall the stream
+    assert res["last_created_at"] == "2026-06-05T03:00:00Z"
+
+
+# ── RED 3 · failed item credits 0 (only the passed dimension accrues) ────────
+def test_failed_item_credits_zero(tmp_path):
+    busc = _mk_bus()
+    _ins(busc, "v-2", "data_002", False, False, 0.8,
+         [{"id": "c1", "pass": True}, {"id": "c4", "pass": False}],
+         "2026-06-05T11:22:00Z")
+    cdir = tmp_path / "cl"; cdir.mkdir()
+    _write_checklist(cdir, "data_002", [
+        {"id": "c1", "point": "公式", "dimension": "calc-formula"},
+        {"id": "c4", "point": "隐私", "dimension": "hallucination-control"}])
+    creditc = _mk_credit()
+
+    res = bus.credit_dimensions_from_bus(
+        busc, creditc, str(cdir), placeholder="?", dimension_for=_stub_dim)
+
+    assert res["processed"] == 1
+    assert _dim(creditc, "calc-formula") == pytest.approx((0.8, 1))
+    assert _dim(creditc, "hallucination-control") is None  # failed → 0
+
+
+# ── RED 4 · since watermark filters already-settled verdicts ─────────────────
+def test_since_watermark_filters(tmp_path):
+    busc = _mk_bus()
+    _ins(busc, "v-1", "data_001", True, False, 0.9,
+         [{"id": "c1", "pass": True}], "2026-06-05T02:47:00Z")
+    _ins(busc, "v-2", "data_002", True, False, 0.8,
+         [{"id": "c1", "pass": True}], "2026-06-05T11:22:00Z")
+    cdir = tmp_path / "cl"; cdir.mkdir()
+    _write_checklist(cdir, "data_001", [{"id": "c1", "dimension": "calc-formula"}])
+    _write_checklist(cdir, "data_002", [{"id": "c1", "dimension": "coverage"}])
+    creditc = _mk_credit()
+
+    res = bus.credit_dimensions_from_bus(
+        busc, creditc, str(cdir), since="2026-06-05T02:47:00Z",
+        placeholder="?", dimension_for=_stub_dim)
+
+    assert res["processed"] == 1
+    assert _dim(creditc, "calc-formula") is None  # data_001 already settled
+    assert _dim(creditc, "coverage") is not None

--- a/tests/test_fde_verdict_bus_dimension.py
+++ b/tests/test_fde_verdict_bus_dimension.py
@@ -37,7 +37,7 @@ def _ins(conn, verdict_id, task_uid, overall_pass, veto_failed, score, items, cr
     conn.execute(
         "INSERT INTO fde_verdicts (verdict_id, task_uid, source, overall_pass, "
         "veto_failed, score, items, created_at) VALUES (?,?,?,?,?,?,?,?)",
-        (verdict_id, task_uid, "v5", int(overall_pass), int(veto_failed), score,
+        (verdict_id, task_uid, "soul", int(overall_pass), int(veto_failed), score,
          json.dumps(items), created_at))
     conn.commit()
 

--- a/tests/test_fde_verdict_bus_reader.py
+++ b/tests/test_fde_verdict_bus_reader.py
@@ -38,7 +38,7 @@ def _mk_bus():
 
 
 def _ins(conn, verdict_id, task_uid, overall_pass, veto_failed, score, items, created_at,
-         source="v5"):
+         source="soul"):  # soul = the authoritative PoI fitness source (settles)
     conn.execute(
         "INSERT INTO fde_verdicts (verdict_id, task_uid, source, overall_pass, "
         "veto_failed, score, items, created_at) VALUES (?,?,?,?,?,?,?,?)",
@@ -121,6 +121,50 @@ def test_peek_is_readonly_and_lists_rows():
     # since filter
     assert len(bus.peek_fde_verdicts(busc, since="2026-06-05T02:47:00Z",
                                      placeholder="?")) == 1
+
+
+# ── RED · only authoritative source ('soul') settles; kairos-opus二审 excluded ─
+# (platform-soul 2026-06-06: V5 adds Kairos Opus adversarial 二审 as
+# source='kairos-opus'; settling those double-counts the same task's PoI — the
+# reader must settle only the soul 一审 fitness signal.)
+def test_only_soul_source_settles_kairos_excluded():
+    busc = _mk_bus()
+    _ins(busc, "v-soul", "data_001", True, False, 1.0, ITEMS, "2026-06-06T01:00:00Z",
+         source="soul")
+    _ins(busc, "v-kairos", "data_001", True, False, 0.9, ITEMS, "2026-06-06T02:00:00Z",
+         source="kairos-opus")
+    creditc = _mk_credit()
+
+    res = bus.from_fde_verdicts(busc, creditc, placeholder="?")
+
+    # only the soul 一审 settled (kairos-opus 二审 skipped → no double-count)
+    assert res["processed"] == 1
+    assert _credit(creditc, "fde-capsule-data_001") == pytest.approx((1.0, 1))
+    # watermark advances only past the settled (soul) row, not the skipped kairos row
+    assert res["last_created_at"] == "2026-06-06T01:00:00Z"
+
+
+def test_real_live_tag_fde_capsule_v5_settles():
+    # production fde_verdicts tags the 一审 rows source='fde-capsule-v5' (verified
+    # 2026-06-06), not 'soul' — the live loop must keep settling those.
+    busc = _mk_bus()
+    _ins(busc, "v-live", "data_001", True, False, 1.0, ITEMS, "2026-06-06T01:00:00Z",
+         source="fde-capsule-v5")
+    creditc = _mk_credit()
+    res = bus.from_fde_verdicts(busc, creditc, placeholder="?")
+    assert res["processed"] == 1
+    assert _credit(creditc, "fde-capsule-data_001") == pytest.approx((1.0, 1))
+
+
+def test_peek_also_filters_to_settling_sources():
+    busc = _mk_bus()
+    _ins(busc, "v-soul", "data_001", True, False, 1.0, ITEMS, "2026-06-06T01:00:00Z",
+         source="soul")
+    _ins(busc, "v-kairos", "data_001", True, False, 0.9, ITEMS, "2026-06-06T02:00:00Z",
+         source="kairos-opus")
+    rows = bus.peek_fde_verdicts(busc, placeholder="?")
+    assert [r["task_uid"] for r in rows] == ["data_001"]
+    assert len(rows) == 1  # kairos-opus not listed as a would-settle row
 
 
 # ── RED 4 · items already a list (postgres JSONB) is accepted ────────────────

--- a/tests/test_fde_verdict_reconcile_dimension.py
+++ b/tests/test_fde_verdict_reconcile_dimension.py
@@ -1,0 +1,113 @@
+"""Task A3 · reconcile glue settles task-level AND dimension-level in one pass.
+
+`fde_verdict_reconcile.settle_once` runs the task-level spine
+(BUS.from_fde_verdicts) and, when a checklist_dir is configured, the dimension
+credit (BUS.credit_dimensions_from_bus joined to local checklists) over the SAME
+`since` watermark — so one cron pass advances one watermark and both granularities
+settle idempotently. A second pass with the advanced watermark double-credits
+neither. NO LLM.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_HERE))
+from proof import fde_poi_adapter as adp  # noqa: E402
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "fde_verdict_reconcile", _HERE / "ops" / "fde_verdict_reconcile.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _mk_db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE fde_verdicts (id INTEGER PRIMARY KEY, verdict_id TEXT UNIQUE, "
+        "task_uid TEXT, source TEXT, checklist_uid TEXT, overall_pass INT, "
+        "veto_failed INT, score REAL, items TEXT, artifacts TEXT, created_at TEXT)")
+    conn.execute("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, "
+                 "cumulative_impact REAL NOT NULL DEFAULT 0, "
+                 "event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+    conn.commit()
+    return conn
+
+
+def _ins(conn, vid, uid, op, vf, score, items, created_at):
+    conn.execute("INSERT INTO fde_verdicts (verdict_id, task_uid, source, overall_pass, "
+                 "veto_failed, score, items, created_at) VALUES (?,?,?,?,?,?,?,?)",
+                 (vid, uid, "v5", int(op), int(vf), score, json.dumps(items), created_at))
+    conn.commit()
+
+
+def _credit(conn, mk):
+    return conn.execute("SELECT cumulative_impact, event_count FROM poi_credit "
+                        "WHERE memory_key=?", (mk,)).fetchone()
+
+
+def _checklist(cdir, uid, items):
+    (cdir / f"{uid}_checklist.json").write_text(
+        json.dumps({"task_uid": uid, "items": items}, ensure_ascii=False), encoding="utf-8")
+
+
+def _stub_dim(item):
+    return item.get("dimension", "coverage")
+
+
+# ── RED 1 · one pass settles BOTH task capsule and dimension keys ────────────
+def test_settle_once_credits_task_and_dimension(tmp_path):
+    rec = _load()
+    conn = _mk_db()
+    _ins(conn, "v-1", "data_001", True, False, 0.9,
+         [{"id": "c1", "pass": True}], "2026-06-05T02:47:00Z")
+    cdir = tmp_path / "cl"; cdir.mkdir()
+    _checklist(cdir, "data_001", [{"id": "c1", "dimension": "calc-formula"}])
+
+    res = rec.settle_once(conn, None, str(cdir), placeholder="?", dimension_for=_stub_dim)
+
+    assert res["last_created_at"] == "2026-06-05T02:47:00Z"
+    assert _credit(conn, "fde-capsule-data_001") == pytest.approx((0.9, 1))   # task spine
+    assert _credit(conn, adp.dimension_memory_key("calc-formula")) == pytest.approx((0.9, 1))
+
+
+# ── RED 2 · second pass with the advanced watermark double-credits nothing ───
+def test_settle_once_idempotent(tmp_path):
+    rec = _load()
+    conn = _mk_db()
+    _ins(conn, "v-1", "data_001", True, False, 0.9,
+         [{"id": "c1", "pass": True}], "2026-06-05T02:47:00Z")
+    cdir = tmp_path / "cl"; cdir.mkdir()
+    _checklist(cdir, "data_001", [{"id": "c1", "dimension": "calc-formula"}])
+
+    first = rec.settle_once(conn, None, str(cdir), placeholder="?", dimension_for=_stub_dim)
+    second = rec.settle_once(conn, first["last_created_at"], str(cdir),
+                             placeholder="?", dimension_for=_stub_dim)
+
+    assert second["task"]["processed"] == 0
+    assert second["dimension"]["processed"] == 0
+    # credits unchanged after the second pass
+    assert _credit(conn, "fde-capsule-data_001") == pytest.approx((0.9, 1))
+    assert _credit(conn, adp.dimension_memory_key("calc-formula")) == pytest.approx((0.9, 1))
+
+
+# ── RED 3 · no checklist_dir → task-level still settles, dimension skipped ────
+def test_settle_once_without_checklist_dir_still_does_task_level():
+    rec = _load()
+    conn = _mk_db()
+    _ins(conn, "v-1", "data_001", True, False, 0.9,
+         [{"id": "c1", "pass": True}], "2026-06-05T02:47:00Z")
+
+    res = rec.settle_once(conn, None, None, placeholder="?", dimension_for=_stub_dim)
+
+    assert _credit(conn, "fde-capsule-data_001") == pytest.approx((0.9, 1))
+    assert res["dimension"]["processed"] == 0

--- a/tests/test_fde_verdict_reconcile_dimension.py
+++ b/tests/test_fde_verdict_reconcile_dimension.py
@@ -46,7 +46,7 @@ def _mk_db():
 def _ins(conn, vid, uid, op, vf, score, items, created_at):
     conn.execute("INSERT INTO fde_verdicts (verdict_id, task_uid, source, overall_pass, "
                  "veto_failed, score, items, created_at) VALUES (?,?,?,?,?,?,?,?)",
-                 (vid, uid, "v5", int(op), int(vf), score, json.dumps(items), created_at))
+                 (vid, uid, "soul", int(op), int(vf), score, json.dumps(items), created_at))
     conn.commit()
 
 


### PR DESCRIPTION
## Phase A · compass substrate 固化 (dogfood 接通)

Builds on #39 (dimension-level PoI · merged). Three un-gated TDD tasks that turn external buyer verdicts into recallable, credited dimension knowledge — the W6 dogfood底座 v5's copilot recalls before solving the next task.

### A1 · 批量避坑语料 (W6 substrate)
`ops/fde_avoidance_corpus_build.py` — `load_fde_tasks` (latest verdict per task · filename-token fallback for verdicts without task_uid · UTF-8 CJK) + `build_corpus` (injected vtf capsule callables → dimension flywheel).
**实测** (real 6 tasks): c4/c5 避坑 lines present, cross-task accumulation (attachment-use from 5 tasks), recall surfaces dim atoms — 隐私 query → `fde-dim-hallucination-control` top (0.549).

### A2 · 维度 PoI 自动从 verdict-bus (Option C)
`proof/fde_verdict_bus_reader.credit_dimensions_from_bus` — joins each bus verdict to its local `<task_uid>_checklist.json` by task_uid → `credit_dimensions_from_verdict` (passed item → +score on boost key; failed → 0; missing checklist skipped, watermark still advances).
**实测** (real 6 tasks): processed=6, dim PoI lands on boost keys `fde-knowledge/fde-dim-<dim>.md` — attachment-use 23.58/27ev top (most-validated surfaces first).

### A3 · reconcile glue (题级+维度 一趟 settle)
`ops/fde_verdict_reconcile.settle_once` — task spine + dimension credit over the SAME `since` watermark, idempotent. `_resolve_dimension_for` best-effort wires the vtf mapper, degrades gracefully when vtf absent. `COMPASS_FDE_CHECKLIST_DIR` gates the dimension settle.

### Tests
13 new tests (A1 ×5, A2 ×5, A3 ×3). Full suite 814 passed (1 pre-existing Windows http_server temp-file-lock fail, unrelated · green on CI ubuntu/macos). ruff clean. **NO LLM** (热路径无 LLM · 守黑盒). Material only fingerprinted, never copied.

### 诚实边界
机械闭环 LIVE,but 燃料仍是 soul M3 judge — 差第一滴真人专家飞书复核才成真 RSI 飞轮 (anchor #3 · 用户安排 · compass 出复核包).