### PR TITLE
feat(fde): expert-review → PoI settle (north-star fuel intake)

### DIFF
--- a/ops/fde_expert_review_settle.py
+++ b/ops/fde_expert_review_settle.py
@@ -1,0 +1,81 @@
+"""compass · expert-review → PoI settle runner (north-star fuel intake).
+
+The human expert review is the FIRST external, non-self-referential PoI signal
+(anchor #3) — soul's M3 一审 scores v5's own output, so it is self-referential;
+a real domain expert verdict is not. The expert verdict is the 复核状态/分项分
+format (NOT the soul checklist format the fde_verdicts bus carries), so it does
+NOT go through SETTLE_SOURCES / the bus reader — it flows through the DIRECT
+credit_from_verdict adapter. This runner consumes filled expert review records
+(the 飞书 Bitable rows · field contract: T3_feishu_retention_design §2) and
+credits PoI on fde-capsule-<task_uid> — the SAME key the soul task-level + capsule
+pipeline credit, so the expert signal COMPOUNDS on the task capsule.
+
+Idempotent via a 复核时间 watermark (settle only reviews newer than the last).
+NO LLM. Pure mapping + reuse of fde_poi_adapter.credit_from_verdict.
+
+Source of `reviews`: a feishu Bitable export (G3 connected) or any list of
+{task_uid, 复核状态, 分项分, 复核时间} dicts. Wire the feishu fetch in main()
+when the real review table is populated.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+from proof.fde_poi_adapter import (  # noqa: E402
+    DEFAULT_REJECT_DELTA, credit_from_verdict, verdict_memory_key, verdict_to_outcome)
+
+# 复核状态 values that are not yet a verdict (no credit · re-checked next run)
+_PENDING = {"待复核", "pending", "复核中", ""}
+
+
+def _review_time(r: dict) -> str:
+    return str(r.get("复核时间") or r.get("review_at") or r.get("time") or "")
+
+
+def _is_pending(r: dict) -> bool:
+    status = str(r.get("复核状态") or r.get("status") or "").strip()
+    if status in _PENDING:
+        return True
+    # neither pass nor reject label → treat as pending (unknown, don't credit)
+    return verdict_to_outcome(r)["success"] is None
+
+
+def settle_expert_reviews(conn, reviews, now_iso, placeholder="%s", since=None,
+                          reject_delta=DEFAULT_REJECT_DELTA):
+    """Credit PoI from filled expert review records.
+
+    Each review = {task_uid, 复核状态(通过/打回/待复核), 分项分:{dim:score}, 复核时间}.
+    Reviews are processed in 复核时间 order; only those with 复核时间 > `since` are
+    considered (exclusive watermark · no double-credit · pass the previous
+    last_review_at). 待复核/unknown → skipped (recorded). 通过 → +mean(分项分)/10;
+    打回 → reject_delta. Credit lands on fde-capsule-<task_uid>. The review's
+    复核时间 is the credit timestamp. placeholder='%s' psycopg2 / '?' sqlite.
+
+    Returns {processed, settled:[{task_uid, delta, action_outcome}],
+    skipped_pending:[task_uid...], last_review_at}."""
+    ordered = sorted(reviews, key=_review_time)
+    settled = []
+    skipped_pending = []
+    last_review_at = since
+    processed = 0
+    for r in ordered:
+        rt = _review_time(r)
+        if since is not None and rt <= since:
+            continue  # already settled (at/under watermark)
+        processed += 1
+        last_review_at = rt or last_review_at
+        uid = str(r.get("task_uid") or r.get("source_uid") or "").strip()
+        if _is_pending(r):
+            skipped_pending.append(uid)
+            continue
+        mk = verdict_memory_key(r)
+        res = credit_from_verdict(conn, r, mk, rt or now_iso, placeholder,
+                                  reject_delta=reject_delta)
+        settled.append({"task_uid": uid, "delta": res["delta"],
+                        "action_outcome": res["action_outcome"]})
+
+    return {"processed": processed, "settled": settled,
+            "skipped_pending": skipped_pending, "last_review_at": last_review_at}

--- a/tests/test_fde_expert_review_settle.py
+++ b/tests/test_fde_expert_review_settle.py
@@ -1,0 +1,89 @@
+"""Task · expert-review → PoI settle (the real north-star fuel intake).
+
+The human expert review is the FIRST non-self-referential PoI signal (anchor #3).
+It does NOT flow through the fde_verdicts bus (that is the soul checklist path
+filtered by SETTLE_SOURCES) — the expert verdict is the 复核状态/分项分 format and
+flows through the DIRECT credit_from_verdict adapter. This settle runner reads
+filled expert review records (the 飞书 Bitable rows · field contract per
+T3_feishu_retention_design §2) and credits PoI on fde-capsule-<task_uid> — the
+SAME key the soul task-level + capsule pipeline credit, so the expert signal
+compounds on the task capsule. Idempotent via a 复核时间 watermark. NO LLM.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN))
+from ops import fde_expert_review_settle as ers  # noqa: E402
+from proof import fde_poi_adapter as adp  # noqa: E402
+
+NOW = "2026-06-06T12:00:00Z"
+
+
+def _db():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE poi_credit (memory_key TEXT PRIMARY KEY, "
+                 "cumulative_impact REAL NOT NULL DEFAULT 0, "
+                 "event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+    conn.commit()
+    return conn
+
+
+def _credit(conn, uid):
+    return conn.execute("SELECT cumulative_impact, event_count FROM poi_credit "
+                        "WHERE memory_key=?", (adp.verdict_memory_key({"task_uid": uid}),)).fetchone()
+
+
+# ── RED 1 · a 通过 review credits the task capsule (mean(分项分)/10) ──────────
+def test_pass_review_credits_capsule():
+    conn = _db()
+    reviews = [{"task_uid": "data_004", "复核状态": "通过",
+                "分项分": {"计算": 9, "证据链": 8, "格式": 10}, "复核时间": "2026-06-06T09:00:00Z"}]
+
+    res = ers.settle_expert_reviews(conn, reviews, NOW, placeholder="?")
+
+    assert res["processed"] == 1
+    # mean(9,8,10)/10 = 0.9
+    assert _credit(conn, "data_004") == pytest.approx((0.9, 1))
+
+
+# ── RED 2 · a 打回 review applies the negative signal ────────────────────────
+def test_reject_review_negative_credit():
+    conn = _db()
+    reviews = [{"task_uid": "data_001", "复核状态": "打回",
+                "分项分": {"完整性": 4}, "复核时间": "2026-06-06T09:00:00Z"}]
+    res = ers.settle_expert_reviews(conn, reviews, NOW, placeholder="?")
+    assert res["processed"] == 1
+    row = _credit(conn, "data_001")
+    assert row[0] == pytest.approx(adp.DEFAULT_REJECT_DELTA)
+
+
+# ── RED 3 · 待复核 (pending) is skipped, no credit ───────────────────────────
+def test_pending_review_skipped():
+    conn = _db()
+    reviews = [{"task_uid": "data_002", "复核状态": "待复核", "复核时间": "2026-06-06T09:00:00Z"}]
+    res = ers.settle_expert_reviews(conn, reviews, NOW, placeholder="?")
+    assert res["settled"] == []
+    assert res["skipped_pending"] == ["data_002"]
+    assert _credit(conn, "data_002") is None
+
+
+# ── RED 4 · 复核时间 watermark filters already-settled reviews ───────────────
+def test_since_watermark_filters():
+    conn = _db()
+    reviews = [
+        {"task_uid": "data_003", "复核状态": "通过", "分项分": {"x": 10},
+         "复核时间": "2026-06-06T08:00:00Z"},
+        {"task_uid": "data_004", "复核状态": "通过", "分项分": {"x": 10},
+         "复核时间": "2026-06-06T10:00:00Z"}]
+    res = ers.settle_expert_reviews(conn, reviews, NOW, placeholder="?",
+                                    since="2026-06-06T08:00:00Z")
+    assert res["processed"] == 1
+    assert _credit(conn, "data_003") is None       # already settled (at watermark)
+    assert _credit(conn, "data_004") is not None
+    assert res["last_review_at"] == "2026-06-06T10:00:00Z"


### PR DESCRIPTION
专家复核燃料入口。**关键纠正**:专家 verdict(复核状态/分项分)**不走** fde_verdicts bus/SETTLE_SOURCES(那是 soul checklist 路径)—— 走 `credit_from_verdict` 直接 adapter,此前无生产调用方(只测试)。

`settle_expert_reviews` 读填好的飞书复核行 → credit `fde-capsule-<task_uid>`(与 soul/bus 题级 + 胶囊管线同一 key → 复利)。复核时间水位幂等。e2e 验证:data_004 通过 → +0.84 落共享胶囊键。4 测绿。NO LLM。

接通后:第一份真专家复核表(用户安排)→ 飞书行 → settle → 北极星飞轮第一次烧真外部燃料(非 AI 自评)。