### PR TITLE
feat(fde): feishu Bitable → expert-review settle wrapper

### DIFF
--- a/ops/fde_expert_review_settle.py
+++ b/ops/fde_expert_review_settle.py
@@ -19,6 +19,7 @@ when the real review table is populated.
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -29,6 +30,26 @@ from proof.fde_poi_adapter import (  # noqa: E402
 
 # 复核状态 values that are not yet a verdict (no credit · re-checked next run)
 _PENDING = {"待复核", "pending", "复核中", ""}
+
+# the 分项分 columns the expert fills in the 飞书 Bitable (packet form §3 · RUBRIC §10).
+SCORE_FIELDS = ("引用准确性", "覆盖完整性", "防编造(幻觉)", "附件运用",
+                "计算/定量", "产物格式可用", "行业体例", "时效性")
+
+
+def bitable_record_to_review(record: dict, score_fields=SCORE_FIELDS) -> dict:
+    """Map a feishu Bitable record ({record_id, fields:{列名:值}}) → review dict
+    {task_uid, 复核状态, 分项分, 复核理由, 复核人, 复核时间}. 分项分 collects the
+    numeric score columns present. No 复核状态 → '' → pending (skipped on settle)."""
+    f = record.get("fields") or record
+    scores = {k: f[k] for k in score_fields if isinstance(f.get(k), (int, float))}
+    return {
+        "task_uid": str(f.get("task_uid") or f.get("题目编号") or "").strip(),
+        "复核状态": str(f.get("复核状态") or "").strip(),
+        "分项分": scores,
+        "复核理由": f.get("复核理由") or "",
+        "复核人": f.get("复核人") or "",
+        "复核时间": str(f.get("复核时间") or ""),
+    }
 
 
 def _review_time(r: dict) -> str:
@@ -79,3 +100,73 @@ def settle_expert_reviews(conn, reviews, now_iso, placeholder="%s", since=None,
 
     return {"processed": processed, "settled": settled,
             "skipped_pending": skipped_pending, "last_review_at": last_review_at}
+
+
+# ─── main() · read reviews (feishu Bitable or local JSON) → settle ───────────
+
+def _load_feishu_records(app_token, table_id):
+    """Read all records from a feishu Bitable via the vtf feishu_client (G3
+    connected). main()-only; resolves the client from $COMPASS_VTF_DIR or sibling."""
+    import importlib.util
+    candidates = []
+    env = os.environ.get("COMPASS_VTF_DIR")
+    if env:
+        candidates.append(Path(env))
+    candidates.append(_HERE.parent.parent / "vertical-task-factory" / "fde-toolbox")
+    for c in candidates:
+        fc = c / "feishu_client.py"
+        if fc.exists():
+            spec = importlib.util.spec_from_file_location("feishu_client", fc)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            token = mod.tenant_token()
+            resp = mod.read_bitable_records(app_token, table_id, token)
+            return (resp.get("data") or {}).get("items") or []
+    raise SystemExit("[expert] feishu_client not found — set COMPASS_VTF_DIR")
+
+
+def main(argv=None):
+    import argparse
+    import json
+    import sqlite3
+    ap = argparse.ArgumentParser(description="Settle expert reviews → PoI.")
+    ap.add_argument("--input", help="local JSON file: list of bitable records or reviews")
+    ap.add_argument("--feishu", action="store_true", help="read from a feishu Bitable")
+    ap.add_argument("--app-token", help="feishu Bitable app_token (with --feishu)")
+    ap.add_argument("--table-id", help="feishu Bitable table_id (with --feishu)")
+    ap.add_argument("--credit-db", help="sqlite path for poi_credit (default: in-memory dry-run)")
+    ap.add_argument("--since", help="exclusive 复核时间 watermark (skip already-settled)")
+    args = ap.parse_args(argv)
+
+    if args.feishu:
+        records = _load_feishu_records(args.app_token, args.table_id)
+    elif args.input:
+        with open(args.input, encoding="utf-8") as f:
+            records = json.load(f)
+    else:
+        raise SystemExit("[expert] give --input <json> or --feishu --app-token --table-id")
+
+    reviews = [bitable_record_to_review(r) for r in records]
+    now_iso = os.environ.get("COMPASS_EXPERT_NOW") or _utc_now()
+
+    conn = sqlite3.connect(args.credit_db or ":memory:")
+    conn.execute("CREATE TABLE IF NOT EXISTS poi_credit (memory_key TEXT PRIMARY KEY, "
+                 "cumulative_impact REAL NOT NULL DEFAULT 0, "
+                 "event_count INTEGER NOT NULL DEFAULT 0, last_impact_at TEXT)")
+    conn.commit()
+    res = settle_expert_reviews(conn, reviews, now_iso, placeholder="?", since=args.since)
+    conn.commit()
+    print(f"[expert] processed={res['processed']} settled={len(res['settled'])} "
+          f"pending={res['skipped_pending']} watermark→{res['last_review_at']}")
+    for s in res["settled"]:
+        print(f"  · {s['task_uid']}: {s['delta']:+.4f} ({s['action_outcome']})")
+    return 0
+
+
+def _utc_now():
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fde_expert_review_settle.py
+++ b/tests/test_fde_expert_review_settle.py
@@ -87,3 +87,39 @@ def test_since_watermark_filters():
     assert _credit(conn, "data_003") is None       # already settled (at watermark)
     assert _credit(conn, "data_004") is not None
     assert res["last_review_at"] == "2026-06-06T10:00:00Z"
+
+
+# ── RED 5 · map a feishu Bitable record → review dict (分项分 from score columns)
+def test_bitable_record_to_review():
+    record = {"record_id": "rec1", "fields": {
+        "task_uid": "data_004", "复核状态": "通过",
+        "引用准确性": 8, "覆盖完整性": 7, "防编造(幻觉)": 10,
+        "复核理由": "归因成立", "复核人": "张三", "复核时间": "2026-06-06T14:00:00Z"}}
+
+    r = ers.bitable_record_to_review(record)
+
+    assert r["task_uid"] == "data_004"
+    assert r["复核状态"] == "通过"
+    assert r["分项分"] == {"引用准确性": 8, "覆盖完整性": 7, "防编造(幻觉)": 10}
+    assert r["复核时间"] == "2026-06-06T14:00:00Z"
+
+
+# ── RED 6 · a record with no 复核状态 maps to pending (skipped on settle) ─────
+def test_bitable_record_missing_status_is_pending():
+    record = {"fields": {"task_uid": "data_005"}}
+    r = ers.bitable_record_to_review(record)
+    assert ers._is_pending(r)
+
+
+# ── RED 7 · settle a list of bitable records end-to-end ──────────────────────
+def test_settle_from_bitable_records():
+    conn = _db()
+    records = [
+        {"fields": {"task_uid": "data_004", "复核状态": "通过", "引用准确性": 10,
+                    "复核时间": "2026-06-06T14:00:00Z"}},
+        {"fields": {"task_uid": "data_005", "复核状态": "待复核",
+                    "复核时间": "2026-06-06T14:01:00Z"}}]
+    reviews = [ers.bitable_record_to_review(rec) for rec in records]
+    res = ers.settle_expert_reviews(conn, reviews, NOW, placeholder="?")
+    assert _credit(conn, "data_004") == pytest.approx((1.0, 1))
+    assert res["skipped_pending"] == ["data_005"]


### PR DESCRIPTION
把专家复核飞书多维表格接进 settle。bitable_record_to_review 映射飞书行(fields)→ review dict(分项分 从分数列)。main() 从飞书 Bitable(--feishu · 经 vtf feishu_client G3)或本地 JSON(--input)读 → settle → poi_credit。7 测绿(含 bitable 映射+e2e)。NO LLM。

流程:用户飞书建多维表格(导入飞书复核表_导入.csv 6 行)→ 专家填 复核状态/分项分/理由 → `python ops/fde_expert_review_settle.py --feishu --app-token X --table-id Y` 一条命令落 PoI。