### PR TITLE
docs: compass 云 substrate 部署设计 + 实施计划

### DIFF
--- a/docs/plans/2026-06-06-compass-cloud-substrate-design.md
+++ b/docs/plans/2026-06-06-compass-cloud-substrate-design.md
@@ -1,0 +1,76 @@
+# compass 云 substrate 部署 — 设计文档（2026-06-06）
+
+> 状态:设计批准(brainstorming 收敛)· 执行分期 · P2+ gated on 平台签 token。
+> 本文档不 ship 部署 · 出实施 plan 见配套 writing-plans。
+
+## 0. 目标(用户确认:两者都要)
+
+1. **多 agent 共享 substrate** — v5/v7/kairos 读写**同一份**云端记忆,真正的跨 agent 记忆胶囊(= Phase B · agent-first substrate)。
+2. **个人跨设备** — 你任何机器/手机访问同一份 compass 记忆。
+
+诚实边界:GPU 不是"共享"的 enabler(共享=云部署架构);GPU 买的是 **reranker 默认开(+0.167 P@5)+ 速度 + 并发**。
+
+## 1. 架构裁定:云权威 + 瘦客户端(A 起步 → C 演进)
+
+放弃"双向文件同步"(B · 类比比特币分布式账本 · 需冲突共识 · 记忆不需拜占庭容错 = 杀鸡用牛刀 · 踩 anchor #3 D 维护)。
+
+**A(起步)**:云跑权威 daemon,所有读写打云。**"双向同步"被溶解为单写权威** —— 一条 ingest 路径写同一份云语料 = **零冲突**,这就是绕开同步地雷的本质。
+**C(演进)**:本地加**只读副本**(单向从云拉)供离线 recall + 提速 · 写仍去云 · 仍零冲突。
+
+## 2. 拓扑(spot/持久分离 · 核心抗抢占)
+
+竞价(spot)T4 随时被回收 → **无状态算力(spot OK)与有状态数据(必须持久)分开**。
+
+```
+持久 CPU 服务器(现有 · 4核16G180G · up21天)        spot T4(GPU · 便宜 · 可丢)
+├─ postgres(poi_credit · 权威 · 已在此)   ←ingest写── GPU daemon(bge-m3 + reranker 默认开)
+├─ 语料真相源(memory .md · 单一真相)      ←启动拉──→  ├─ 内存语料 + index 缓存(可重建)
+└─ CPU daemon(冷备 · T4挂时拉起)                       └─ PoI 快照文件(从 CPU 服拉 · 非每查 live)
+       ↑ T4 被回收 → 客户端 fallback 到这                ↑ 客户端优先打(GPU 快)
+```
+
+- **T4 不需要自己的权威 DB**(在临时盘 = 被回收丢数据)· 它读 CPU 服的 postgres + 拉语料/快照到本地缓存 · recall 全内存。
+- **现有持久 CPU 服 = 灾备(DR)** —— 数据持久 + 降级可用。**不用第二台 T4**(2 台 spot 可能同时被回收 = 解决不了 DR · 混淆 HA/DR · 浪费 spot 省下的钱)。
+- spot 被回收 → 收 2 分钟终止信号 → drain 在途 ingest → 新 spot 自动拉起 + 重建 index。
+
+## 3. 实测资源占用(2026-06-06 SSH cloud 实测 · 非臆测)
+
+CPU 服现状:CPU load 0.4-0.8/4核(充裕)· 硬盘余 49G(72%用)· **内存紧**:用 6.2G + **swap 已用 6.5G**(一个 4.1G python 进程=平台/v5 turf)· 真空闲 478M · available 8.7G。
+
+compass 在 CPU 服当**轻租客**:
+- **硬盘**:语料(<500MB)+ index(几十 MB)· 49G 余量随便用 ✅
+- **CPU**:recall 短峰(347ms/查)· load 充裕 ✅
+- **内存**:⚠️ 箱子已 swap → **冷备**(平时≈0 内存 · 只 postgres 增量 + 语料躺盘)· T4 挂时才载 bge-m3(~1.7G · 那时 available 8.7G 够临时)· 失败切换 ~1 分钟。**不加常驻热备**(避免给已 swap 的箱子加压)。
+
+实测数据点:本地 daemon working set 1766MB(主要 bge-m3 模型)· 本项目 memory 语料仅 5.2MB/961 文件(1.8GB 是整个 ~/.claude/projects 含 transcript · **别镜像**,只镜像 memory 语料)。
+
+## 4. 多 agent 鉴权(Phase B · gated G-token)
+
+云 daemon 暴露 ~17 MCP 工具(token-gated TCP · 复用 v5 已建传输)+ per-agent scope(Phase B authz 层 · 见 2026-06-06-compass-mcp-3agent-dogfood-design.md)。平台签 v5/v7/kairos token + 注册 endpoint。
+
+## 5. 分期(降险 · 每期可独立验证)
+
+- **P0 · 立 T4 GPU daemon**(只你 · 无 agent):spot T4 起 daemon + 拉语料/快照 + reranker 默认开 + 客户端(你本机 recall hook)指向 T4。验:跨设备 recall 通 + reranker lift 生效 + 抗抢占(手动 kill 验 fallback)。
+- **P1 · CPU 冷备 + ingest 写路径**:CPU 服装冷备 daemon(systemd · 抢占信号触发)+ 所有 ingest 走云 daemon(单写权威)。验:T4 kill → 1 分钟 fallback · ingest 落持久。**先修 CJK-surrogate ingest 崩 bug**(P1 必修前置)。
+- **P2 · Phase B 多 agent**(gated 平台 token):per-agent scope + v5/v7/kairos wire MCP client。验:每 agent recall+ingest 实测。
+- **P3 · 本地只读缓存(C)**:离线 recall 副本。
+
+## 6. 必修风险
+
+| 风险 | 缓解 |
+|---|---|
+| spot 被回收 | 状态在持久 CPU 服 · 冷备 fallback · 自动重拉 |
+| 网络依赖 recall | P3 本地只读缓存离线兜底 |
+| **CJK-surrogate ingest 崩**(调研:跨设备 ingest 静默失败根因) | **P1 必修前置** · ingest 路径不能崩在 CJK |
+| 公网暴露 MCP/语料 | token 鉴权 + TLS + 防火墙白名单 |
+| CPU 服内存已 swap | 冷备(不加常驻热备)· compass 轻租客 |
+| T4 常驻成本 | spot 竞价(便宜)· 仅 GPU 算力上 spot |
+
+## 7. gated 边界
+
+- G-token(P2):平台签 v5/v7/kairos token + 注册 endpoint。
+- G-spot:T4 spot 实例 + 抢占处理(运维)。
+- 不碰平台/v5 在 CPU 服的现有进程(4.1G python = 它们 turf)。
+
+## 关联
+[[reference_compass_rsi_fde_role_progress]] · 2026-06-06-compass-mcp-3agent-dogfood-design.md(Phase B authz)· 跨设备 ingest 缺口(缺口1)· 实测:SSH cloud 2026-06-06。

--- a/docs/plans/2026-06-06-compass-cloud-substrate-plan.md
+++ b/docs/plans/2026-06-06-compass-cloud-substrate-plan.md
@@ -1,0 +1,98 @@
+# compass 云 substrate 部署 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+> **执行须 fresh session**(本设计 session 太长 · R3)· P0/P1 需用户先 provision spot T4 + CPU 服 sudo · P2 gated 平台签 token。
+
+**Goal:** 把 compass 部署成 spot-T4-GPU + 持久-CPU-服 的云 substrate,实现多 agent 共享记忆 + 个人跨设备,抗 spot 抢占。
+
+**Architecture:** 云权威 daemon(A→C)· 单写权威(零冲突)· spot T4 纯 GPU 算力 / 持久 CPU 服存状态 + 冷备 fallback。设计见 `2026-06-06-compass-cloud-substrate-design.md`。
+
+**Tech Stack:** Python · daemon.py · bge-m3/bge-reranker-v2-m3 · postgres · systemd · ssh · spot GPU 实例。
+
+---
+
+## Phase 0 · un-gated 代码前置(可现在 TDD · 不需 T4)
+
+### Task 1: 修 CJK-surrogate ingest 崩 bug(P1 必修前置 · 独立价值)
+
+**背景:** 调研定位跨设备 ingest 静默失败根因 = CJK-name surrogate 崩(`session_20260605_dual_flywheel_wiring` Finding1)。云权威下所有 ingest 走一条路,这条路**不能崩在 CJK**。
+
+**Files:**
+- 先 systematic-debugging 定位:`Grep` `surrogate|encode|UnicodeEncodeError|gbk` in `daemon.py` / `bridge` / ingest 路径
+- Modify: ingest 路径文件(定位后定)
+- Test: `tests/test_ingest_cjk_surrogate.py`
+
+**Step 1:** 写失败测试 — ingest 一条含 CJK + emoji + surrogate-pair 字符的 obs → 断言不抛 UnicodeError 且条目落库。
+**Step 2:** 跑测试确认 FAIL(复现崩)。
+**Step 3:** 最小修(UTF-8 显式 + surrogatepass/errors 处理 · 参 PR#37 `e2e74de` bridge UTF-8 修法)。
+**Step 4:** 跑测试 PASS + 跑既有 ingest 测试无回归。
+**Step 5:** Commit `fix(ingest): CJK surrogate 不崩(跨设备 ingest 前置)`。
+
+### Task 2: 语料 seed/pull 脚本(CPU 服 ↔ T4)
+
+**Files:** Create `ops/corpus_sync.py` · Test `tests/test_corpus_sync.py`
+- `push_corpus(local_memory_dir, remote)` — 只镜像 memory `.md`(排除 transcript · 实测仅 ~5MB/项目 · 非 1.8GB)· rsync/scp 封装
+- `pull_corpus(remote, local_cache)` — T4 启动时拉
+- TDD:mock 文件树 → 断言只 .md 被选 + transcript 排除 + 幂等(再跑无重传)。
+- Commit。
+
+### Task 3: PoI 快照 pull(T4 读快照非 live postgres)
+
+**Files:** 复用既有 `regen_poi_snapshot.sh` / poi_credit_snapshot.json 机制(daemon 本就读快照)· Create `ops/snapshot_pull.py` · Test。
+- T4 daemon 启动 + 定期从 CPU 服拉 `poi_credit_snapshot.json`(cron regen on CPU 服)。
+- TDD:mock 快照 → 断言 boost 读到。
+- Commit。
+
+### Task 4: 客户端 fallback(T4 优先 · 挂则 CPU 服)
+
+**Files:** Modify 客户端 recall 入口(daemon client / recall hook)· Test `tests/test_client_fallback.py`
+- `recall_with_fallback(query, primary=T4_endpoint, fallback=CPU_endpoint)` — primary 超时/拒连 → fallback。
+- TDD:mock primary 抛 ConnectionError → 断言走 fallback + 返回结果。
+- Commit。
+
+---
+
+## Phase 1 · CPU 服冷备 + ingest 写路径(需 CPU 服 sudo · 用户 ops)
+
+### Task 5: CPU 服冷备 daemon systemd(冷备 · 抢占触发)
+**runbook(非 TDD · ops):** CPU 服装 compass daemon(CPU 模式 · `ZMM_DEVICE=cpu`)· systemd unit `compass-daemon-fallback.service`(`WantedBy` 手动/触发 · 非 always · 守内存:实测箱子已 swap → 平时不启)· 健康端点。验:手动 `systemctl start` → 1 分钟内 recall 可服(载 bge-m3 ~1.7G · 那时 available 8.7G 够)。
+
+### Task 6: ingest 统一写云(单写权威)
+**Files:** Modify stop-hook ingest + agent ingest → 都打云 daemon ingest API(非本地写)· Test。
+- TDD:mock ingest API → 断言写转发 + 本地不再独立写语料(消灭多写)。
+- Commit。
+
+---
+
+## Phase 2 · spot T4 GPU daemon(需用户 provision T4 · ops)
+
+### Task 7: T4 spot 实例起 GPU daemon
+**runbook(ops):** spot T4 · 装 daemon + 拉语料(Task 2)+ 拉快照(Task 3)+ `COMPASS_PROD_RERANK=1`(reranker 默认开 · T4 GPU ~0.6-0.9s)· systemd + spot 抢占信号 handler(收 2min 警告 → drain ingest → 标记下线让客户端 fallback)· 自动重拉(spot fleet restart)。
+
+### Task 8: 客户端指向 T4 + 抗抢占验证
+**runbook:** 你本机 recall hook primary=T4 · fallback=CPU 服(Task 4)· 验:跨设备 recall 通 + reranker lift 生效 + **手动 kill T4 daemon → 1 分钟 fallback 到 CPU 服**(实测抗抢占)。
+
+---
+
+## Phase 3 · 多 agent(gated G-token · 平台签 token)
+
+### Task 9: Phase B authz scope 层(见 2026-06-06-compass-mcp-3agent-dogfood-design.md §4 B2)
+per-tool scope 强制 · 平台签 v5/v7/kairos token + 注册 endpoint · 每 agent recall+ingest 实测。
+
+---
+
+## Phase 4 · 本地只读缓存(C · 离线)
+
+### Task 10: 本地只读副本(单向从云拉 · 离线 recall)
+单向 pull replica · 写仍去云 · 零冲突 · 离线 recall 兜底。
+
+---
+
+## DONE 判定
+- P0:CJK ingest 不崩 + sync/snapshot/fallback 脚本 TDD 绿(可现在做 · 不需 T4)
+- P1:CPU 冷备可 1 分钟接管 + ingest 单写权威
+- P2:T4 GPU daemon LIVE + reranker 默认开 + 抗抢占实测(kill→fallback)
+- P3:多 agent 共享(gated)· P4:离线缓存
+
+## 关联
+设计 `2026-06-06-compass-cloud-substrate-design.md` · Phase B `2026-06-06-compass-mcp-3agent-dogfood-design.md`。


### PR DESCRIPTION
brainstorming 收敛的 compass 上云设计 + 分期实施 plan。

**架构**:云权威 daemon(A→C · 弃双向同步=单写权威零冲突)· spot T4 纯 GPU 算力 / 持久 CPU 服存状态+冷备 fallback · 实测资源(CPU 服已 swap→冷备轻租客)。

**分期**:P0 un-gated 代码可现在 TDD(CJK ingest 修 + sync/snapshot/fallback)· P1 CPU 冷备+单写 · P2 spot T4 GPU daemon(需 provision)· P3 多 agent gated 平台 token · P4 离线缓存。

执行须 fresh session(本设计 session 太长)。