### PR TITLE
fix(ingest): recover CJK lone-surrogate crash (cross-device ingest prereq)

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -1081,6 +1081,23 @@ def serve():
     log("daemon stopped")
 
 
+def _recover_surrogates(s: str) -> str:
+    """Sanitize lone surrogates (\\udc80-\\udcff) that crash write_text(utf-8).
+
+    They come from an upstream gbk-decode-as-UTF-8/surrogateescape (the Windows MCP
+    client · session_20260605 Finding 1: Chinese obs all crash, ASCII passes). The
+    single cloud-substrate ingest path must never die on one bad-encoded obs:
+    re-encode to the original bytes + decode as gbk (the Windows default ·
+    round-trips the CJK); on failure 'replace' so it degrades gracefully. Valid
+    input (ASCII / real CJK · no surrogates) is returned untouched."""
+    if not any("\ud800" <= c <= "\udfff" for c in s):
+        return s
+    try:
+        return s.encode("utf-8", "surrogateescape").decode("gbk")
+    except UnicodeError:
+        return s.encode("utf-8", "replace").decode("utf-8")
+
+
 def handle_ingest(req: dict) -> dict:
     """v2.0.0 · S5 · ingest text -> compass memory .md + embed + cache.
 
@@ -1107,7 +1124,7 @@ def handle_ingest(req: dict) -> dict:
     import pickle as _pickle
     from datetime import datetime, timezone
 
-    text = (req.get("text") or "").strip()
+    text = _recover_surrogates((req.get("text") or "").strip())
     project = (req.get("project") or "").strip()
     if not text:
         return {"ok": False, "error": "empty text"}
@@ -1119,7 +1136,7 @@ def handle_ingest(req: dict) -> dict:
     mem_dir = Path.home() / ".claude" / "projects" / project / "memory"
     mem_dir.mkdir(parents=True, exist_ok=True)
 
-    fname = (req.get("filename") or "").strip()
+    fname = _recover_surrogates((req.get("filename") or "").strip())
     if not fname:
         ts = time.strftime("%Y%m%d_%H%M%S")
         hsh = abs(hash(text)) % 100000

--- a/tests/test_ingest_cjk_surrogate.py
+++ b/tests/test_ingest_cjk_surrogate.py
@@ -1,0 +1,57 @@
+"""CJK-surrogate ingest crash fix (cross-device ingest prerequisite).
+
+Root cause (reproduced 2026-06-06): the Windows MCP client gbk-decodes a CJK obs
+name/text as UTF-8 with errors='surrogateescape', producing lone surrogates
+(\\udc80-\\udcff). handle_ingest's `out_path.write_text(content, encoding="utf-8")`
+then crashes `UnicodeEncodeError: surrogates not allowed`, killing the whole obs
+(Chinese obs all crash, ASCII passes · session_20260605 Finding 1).
+
+The single cloud-substrate ingest path must NEVER crash on one bad-encoded obs.
+`_recover_surrogates` sanitizes at the boundary: a surrogate-escaped string is
+re-encoded to its original bytes and decoded as gbk (the Windows default ·
+round-trips the CJK); if that fails it falls back to 'replace' so ingest degrades
+gracefully. Valid input (ASCII / real CJK) passes through untouched.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN))
+import daemon as d  # noqa: E402
+
+
+# the exact shape Finding 1 saw: gbk bytes decoded utf-8/surrogateescape
+def _mangle(s: str) -> str:
+    return s.encode("gbk").decode("utf-8", "surrogateescape")
+
+
+# ── RED 1 · surrogate-escaped gbk CJK is recovered to the original CJK ────────
+def test_recovers_gbk_cjk():
+    mangled = _mangle("中文测试")
+    assert "\udc00" <= mangled[0] <= "\udfff"  # precondition: it IS a lone surrogate
+    assert d._recover_surrogates(mangled) == "中文测试"
+
+
+# ── RED 2 · valid input is never mangled ─────────────────────────────────────
+def test_valid_cjk_and_ascii_unchanged():
+    assert d._recover_surrogates("中文") == "中文"      # real CJK has no surrogates
+    assert d._recover_surrogates("hello_123") == "hello_123"
+    assert d._recover_surrogates("") == ""
+
+
+# ── RED 3 · the GUARANTEE · output is always UTF-8 writable (never crashes) ──
+def test_output_is_utf8_writable(tmp_path):
+    for bad in [_mangle("噪音服务延迟"), "\udcae\udcff lone", "x\udcaey"]:
+        out = d._recover_surrogates(bad)
+        # this is the operation that crashed in production — must not raise now
+        (tmp_path / "t.md").write_text(out, encoding="utf-8")
+
+
+# ── RED 4 · unrecoverable surrogate degrades to replacement, no crash ────────
+def test_unrecoverable_degrades_not_crash():
+    # a lone high surrogate that is not a valid gbk byte sequence
+    out = d._recover_surrogates("good\udca0\udca0text")
+    out.encode("utf-8")  # must be encodable (no raise)
+    assert "good" in out and "text" in out


### PR DESCRIPTION
**根因**(已复现):Windows MCP client 把 CJK obs gbk-误当 UTF-8/surrogateescape 解码 → lone surrogate(\udc80-\udcff)→ handle_ingest write_text(utf-8) 崩 'surrogates not allowed'(中文 obs 全崩 · ASCII 通过 · session_20260605 Finding 1)。

云 substrate 所有 ingest 汇一条路,**这条路不能崩在一个坏 obs**。`_recover_surrogates` 在 ingest 边界 sanitize text+filename:先 surrogateescape→gbk 恢复 CJK,失败 replace。正常输入(ASCII/真 CJK 无 surrogate)不动 → **零回归**。

4 测绿(含生产崩的那个 write_text 操作)· 29 ingest/daemon 测试无回归。云 substrate plan 的 P0(跨设备 ingest 前置)。