### PR TITLE
docs(fde): correct 二审 source tag (kairos-deepseek not kairos-opus)

### DIFF
--- a/proof/fde_verdict_bus_reader.py
+++ b/proof/fde_verdict_bus_reader.py
@@ -32,16 +32,21 @@ _SELECT = ("SELECT verdict_id, task_uid, overall_pass, veto_failed, score, "
            "items, created_at FROM fde_verdicts")
 
 # Authoritative PoI fitness sources (allowlist). The 一审 soul checklist verdict
-# is the ONLY PoI source; from 2026-06-06 V5 also writes a Kairos Opus adversarial
-# 二审 as source='kairos-opus' — settling that double-counts the same task's PoI,
-# so it MUST be excluded.
+# is the ONLY PoI source; from 2026-06-06 V5 also writes an adversarial 二审 to
+# the same bus — settling that would double-count the task's PoI, so it MUST be
+# excluded. NOTE the 二审 tag is source='kairos-deepseek' (V5 ran DeepSeek/
+# MiniMax-M3, not Opus — Kairos had no quota), NOT 'kairos-opus' as first assumed.
+# Because this is an ALLOWLIST (settle only the tags below), ANY 二审 source —
+# kairos-deepseek, kairos-opus, or a future judge — is excluded automatically; the
+# exact 二审 tag does not matter. (This robustness is why an allowlist beats a
+# denylist of one specific tag.)
 #
 # Tag reality (verified against production fde_verdicts 2026-06-06): the live 一审
 # rows are tagged source='fde-capsule-v5' (V5 relays soul's checklist_scorer
 # verdict), NOT 'soul' as the platform's WHERE source='soul' request literally
 # stated — an allowlist of just 'soul' would settle NOTHING and break the live
 # loop. So this allows BOTH the real live tag and 'soul' (in case the platform
-# re-tags the 一审 to 'soul' later); either settles, kairos-opus never does.
+# re-tags the 一审 to 'soul' later); either settles, no 二审 ever does.
 # Append the 真人专家 (expert) source HERE when that 飞书 review path lands
 # (anchor #3 north-star fuel). Reverses the original rule A "don't filter source"
 # (FDE_VERDICT_BUS_CONTRACT.md) at the platform's request.

--- a/tests/test_fde_verdict_bus_reader.py
+++ b/tests/test_fde_verdict_bus_reader.py
@@ -123,21 +123,21 @@ def test_peek_is_readonly_and_lists_rows():
                                      placeholder="?")) == 1
 
 
-# ── RED · only authoritative source ('soul') settles; kairos-opus二审 excluded ─
-# (platform-soul 2026-06-06: V5 adds Kairos Opus adversarial 二审 as
-# source='kairos-opus'; settling those double-counts the same task's PoI — the
-# reader must settle only the soul 一审 fitness signal.)
+# ── RED · only authoritative source settles; kairos-deepseek 二审 excluded ────
+# (platform-soul/V5 2026-06-06: V5 adds an adversarial 二审 to the bus; the real
+# tag is source='kairos-deepseek' — V5 ran DeepSeek/MiniMax-M3, not Opus. Settling
+# the 二审 double-counts the task's PoI, so the allowlist excludes ANY 二审 source.)
 def test_only_soul_source_settles_kairos_excluded():
     busc = _mk_bus()
     _ins(busc, "v-soul", "data_001", True, False, 1.0, ITEMS, "2026-06-06T01:00:00Z",
          source="soul")
     _ins(busc, "v-kairos", "data_001", True, False, 0.9, ITEMS, "2026-06-06T02:00:00Z",
-         source="kairos-opus")
+         source="kairos-deepseek")  # the actual production 二审 tag
     creditc = _mk_credit()
 
     res = bus.from_fde_verdicts(busc, creditc, placeholder="?")
 
-    # only the soul 一审 settled (kairos-opus 二审 skipped → no double-count)
+    # only the soul 一审 settled (kairos-deepseek 二审 skipped → no double-count)
     assert res["processed"] == 1
     assert _credit(creditc, "fde-capsule-data_001") == pytest.approx((1.0, 1))
     # watermark advances only past the settled (soul) row, not the skipped kairos row
@@ -161,10 +161,10 @@ def test_peek_also_filters_to_settling_sources():
     _ins(busc, "v-soul", "data_001", True, False, 1.0, ITEMS, "2026-06-06T01:00:00Z",
          source="soul")
     _ins(busc, "v-kairos", "data_001", True, False, 0.9, ITEMS, "2026-06-06T02:00:00Z",
-         source="kairos-opus")
+         source="kairos-deepseek")
     rows = bus.peek_fde_verdicts(busc, placeholder="?")
     assert [r["task_uid"] for r in rows] == ["data_001"]
-    assert len(rows) == 1  # kairos-opus not listed as a would-settle row
+    assert len(rows) == 1  # kairos-deepseek 二审 not listed as a would-settle row
 
 
 # ── RED 4 · items already a list (postgres JSONB) is accepted ────────────────


### PR DESCRIPTION
V5 的对抗二审跑的是 DeepSeek/MiniMax-M3(Kairos 无额度),bus tag 是 source='kairos-deepseek' 非首次假设的 kairos-opus。SETTLE_SOURCES allowlist 本就正确排除它(任何非 allowlist 源都排 = allowlist 优于单 tag denylist 的 robustness)。注释+测试更正到真生产 tag。无代码改动。