### PR TITLE
feat(substrate): cloud substrate Phase 0 Task 2-4 + T4 daemon runbook

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -95,7 +95,13 @@ _BM25_RRF_TOP_K = int(os.environ.get("COMPASS_BM25_RRF_TOP_K", "30"))
 _PROD_RERANK_USE = os.environ.get("COMPASS_PROD_RERANK", "0") == "1"
 _RERANKER_MODEL = os.environ.get(
     "ZMM_RERANKER_MODEL",
-    str(Path.home() / ".cache/modelscope/hub/models/BAAI/bge-reranker-v2-m3"),
+    # local ModelScope path preferred · else HF repo id (mirrors EMBEDDER_MODEL).
+    # 2026-06-07: without the HF fallback, HF-cache-only hosts (e.g. fresh GPU
+    # server) hit "reranker failed · Path .../modelscope/... not found" and
+    # silently fell back to dense order. The exists()-guard fixes that.
+    str(Path.home() / ".cache/modelscope/hub/models/BAAI/bge-reranker-v2-m3")
+    if (Path.home() / ".cache/modelscope/hub/models/BAAI/bge-reranker-v2-m3").exists()
+    else "BAAI/bge-reranker-v2-m3",
 )
 # how many top candidates to feed the cross-encoder before truncating to top_k.
 # benchmark used full haystack (50); production keeps it bounded for latency.

--- a/docs/runbooks/2026-06-07-t4-daemon-bringup.md
+++ b/docs/runbooks/2026-06-07-t4-daemon-bringup.md
@@ -1,0 +1,63 @@
+# Runbook: compass daemon + reranker 上 T4 GPU(2026-06-07 实测)
+
+> Phase 2 Task 7 of `docs/plans/2026-06-06-compass-cloud-substrate-plan.md`.
+> 本 runbook 记录把 compass daemon(bge-m3 + bge-reranker-v2-m3)跑在 Tesla T4 GPU 上的
+> 实测步骤 + 实测数字 + 一个坑。所有步骤已在 43.163.80.46(`ssh t4`)真跑过。
+
+## T4 环境(实测)
+- Tesla T4 15GB · driver 580.126.20 · Ubuntu 22.04.5 · 8C/30G · Python 3.10.12 · 无 nvcc(reranker/embedder 走 pip torch 自带 runtime,无需 CUDA toolkit)。
+
+## 1. 装 GPU 依赖 + 预下模型
+```bash
+pip install --user sentence-transformers          # 拉 torch 2.12+cu130(~2.5G)+ transformers
+python3 ops/_t4_fetch_models.py                    # 验 torch.cuda + 预下 bge-m3(~2.2G)+ bge-reranker-v2-m3(~2.2G)
+```
+实测:torch 2.12.0+cu130 · cuda_available True · Tesla T4 · bge-m3 dim 1024 加载 137s(含下载)· reranker 加载 253s · HF 缓存共 6.4G。HF 在 T4 直连可达(0.0s),无需 hf-mirror。
+
+## 2. 推语料(.md only)
+生产路径用 `ops/corpus_sync.py push --local <memory> --host <t4> --remote ~/.claude/projects/<proj>/memory`(rsync · 幂等)。
+⚠️ **Windows 开发盒无 rsync** → 用等价 tar-over-ssh:
+```bash
+cd <memory_dir> && tar czf - *.md | ssh t4 'cd ~/.claude/projects/<proj>/memory && tar xzf -'
+```
+daemon 只读 `mem_dir.glob("*.md")`(**非递归**,daemon.py:523)。实测推 966 个 .md。
+
+## 3. 起 daemon(GPU + reranker)
+```bash
+ssh t4
+cd ~/compass   # daemon.py 已 scp 至此(daemon 自包含 · 仅可选 query_rewrite,保持 OFF)
+PATH=$HOME/.local/bin:$PATH \
+ZMM_DEVICE=cuda \
+COMPASS_PROD_RERANK=1 \
+ZMM_RERANKER_MODEL=BAAI/bge-reranker-v2-m3 \
+COMPASS_USE_INOTIFY=0 \
+setsid python3 daemon.py > ~/compass_daemon.log 2>&1 < /dev/null &
+```
+- `setsid + </dev/null`:必须。普通 `nohup ... &` 后跟长 for-loop 在同一 ssh 命令里会让 ssh 挂(实测 exit 255 + daemon 没活)。检查就绪要**另起一条 ssh** poll `ss -tln | grep 9876`。
+- 实测:BGE 12.1s 载入 GPU → `listening 127.0.0.1:9876`。
+
+## 🔴 坑:reranker 路径无 HF-fallback
+`daemon.py:96-99` 的 `_RERANKER_MODEL` 默认 = modelscope 缓存路径字符串,**没有** embedder 那样的 `if exists() else "BAAI/..."` 兜底(对比 daemon.py:325-327)。
+HF-cache 机器(如本 T4)上,不设 env 会报 `reranker failed · Path .../modelscope/.../bge-reranker-v2-m3 not found` → 静默 fallback 到 dense 顺序(recall 仍返回但**没 rerank**)。
+- **解(已用)**:起 daemon 时设 `ZMM_RERANKER_MODEL=BAAI/bge-reranker-v2-m3`(从 HF 缓存加载)。
+- **建议根因修(未做 · 留 PR)**:给 `_RERANKER_MODEL` 加与 embedder 一致的 `Path(...).exists() else "BAAI/bge-reranker-v2-m3"` 兜底,消除此 footgun。
+
+## 4. 验证(实测 · verification-before-completion)
+```bash
+ssh t4 'cd ~/compass && python3 _recall_test.py'   # 用 recall_fallback.call_endpoint 发 recall
+```
+实测 3 查询(project=compass-t4-demo · 966 文件语料):
+| query | top hit | 说明 |
+|---|---|---|
+| compass T4 deploy benchmark pass@k | `plan_compass_t4_deploy_benchmark_env_handoff_20260607.md` | 命中正确 |
+| drift guardrail false positive tune out | `session_20260527_drift_loop_open_tuneout.md` | 命中正确 |
+| capstone truncation eval bug | BGE 评估 bug 修复 sessions | 命中正确 |
+
+- reranker engage 确认:日志 `reranker loaded · BAAI/bge-reranker-v2-m3 on cuda · 6.9s` + GPU 占用 2.3G→**6.3G**(双模型)+ 候选顺序相对 dense-only 重排。
+- **延迟实测**:首次 recall 冷启 75.8s(首查嵌入全部 966 文件)· 之后 dense warm 0.2-0.3s · **reranked warm ~4.2s/query**(reranker 跑 `COMPASS_RERANK_CANDIDATES=30` 个 cross-encoder pass)。
+  - ⚠️ 注:plan 估"T4 GPU ~0.6-0.9s"对应单次嵌入,非 30 候选全 rerank。30 候选 reranked ≈ 4s。若要降延迟,调小 `COMPASS_RERANK_CANDIDATES`。
+
+## 当前状态(本 session 结束时)
+- daemon **仍在 T4 跑**(`pgrep -f "python3 daemon.py"` · 127.0.0.1:9876 · GPU 6.3G)。
+- 这是**手动 setsid demo daemon**,**非** systemd。Phase 2 完整 Task 7(systemd unit + spot 抢占 2min handler + drain + 自动重拉)+ Task 8(客户端指 T4 · kill→fallback 实测)= 仍待做(需 spot 实例策略 + 客户端 recall hook 接 recall_with_fallback)。
+- corpus_sync/snapshot_pull/recall_with_fallback 代码已 TDD ship(Phase 0 Task 2/3/4)。

--- a/ops/_t4_fetch_models.py
+++ b/ops/_t4_fetch_models.py
@@ -1,0 +1,24 @@
+"""One-shot: verify torch+CUDA on T4 and pre-download bge-m3 + bge-reranker-v2-m3
+into the HF cache so the compass daemon loads them locally. Run on T4."""
+import time
+
+import torch
+
+print("torch", torch.__version__, "cuda_available", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("gpu", torch.cuda.get_device_name(0))
+
+t0 = time.time()
+print("downloading bge-m3 ...", flush=True)
+from sentence_transformers import SentenceTransformer, CrossEncoder
+
+m = SentenceTransformer("BAAI/bge-m3", device="cuda" if torch.cuda.is_available() else "cpu")
+v = m.encode(["smoke test 中文"], normalize_embeddings=True)
+print("bge-m3 OK dim", len(v[0]), f"{time.time() - t0:.0f}s", flush=True)
+
+t1 = time.time()
+print("downloading bge-reranker-v2-m3 ...", flush=True)
+ce = CrossEncoder("BAAI/bge-reranker-v2-m3", device="cuda" if torch.cuda.is_available() else "cpu")
+s = ce.predict([("q", "doc 中文")])
+print("reranker OK score", float(s[0]), f"{time.time() - t1:.0f}s", flush=True)
+print("ALL MODELS READY", flush=True)

--- a/ops/bootstrap_gpu_server.sh
+++ b/ops/bootstrap_gpu_server.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Bootstrap a fresh GPU server as a compass benchmark-env + daemon host.
+# Idempotent-ish: re-running re-checks each step. Run AS the app user (not root)
+# except the CUDA-toolkit apt step (needs sudo).
+#
+# VERIFICATION STATUS (honest):
+#   [VERIFIED 2026-06-07 on Tesla T4 43.163.80.46]  steps 1,3,4,5 ran clean
+#   [UNVERIFIED · awaits new GPU server]            step 2 (CUDA toolkit/nvcc) +
+#                                                   step 6 (A-cluster compile)
+# The dying T4 had no nvcc, so the nvcc/A-cluster path was never exercised.
+#
+# Usage:
+#   bash bootstrap_gpu_server.sh            # daemon + models + corpus (no A-cluster)
+#   WITH_CUDA_TOOLKIT=1 bash bootstrap_gpu_server.sh   # also install nvcc for A-cluster
+set -uo pipefail
+LOG(){ echo "[$(date '+%H:%M:%S')] $*"; }
+
+APP_DIR="${COMPASS_APP_DIR:-$HOME/compass}"
+CORPUS_PROJECT="${COMPASS_CORPUS_PROJECT:-compass-t4-demo}"
+MEM_REMOTE="$HOME/.claude/projects/$CORPUS_PROJECT/memory"
+
+# ── 1. python deps [VERIFIED] ──────────────────────────────────────────────
+LOG "1/6 pip deps (torch + sentence-transformers)"
+pip install --user --quiet --upgrade pip
+pip install --user --quiet sentence-transformers
+python3 -c "import torch; print('torch', torch.__version__, 'cuda', torch.cuda.is_available(),
+ (torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'NO-GPU'))" || {
+  LOG "torch import/cuda check FAILED"; exit 1; }
+
+# ── 2. CUDA toolkit for A-cluster nvcc [UNVERIFIED · only if WITH_CUDA_TOOLKIT=1] ──
+# A-cluster samples (kernelbench_attention, autolab_radixsort) compile .cu with nvcc.
+# torch ships its own CUDA runtime so the daemon/reranker do NOT need this; only
+# raw-kernel compilation does. Match the toolkit major to the driver's CUDA.
+if [ "${WITH_CUDA_TOOLKIT:-0}" = "1" ]; then
+  LOG "2/6 CUDA toolkit (nvcc) — UNVERIFIED path"
+  if command -v nvcc >/dev/null 2>&1; then
+    LOG "  nvcc already present: $(nvcc --version | tail -1)"
+  else
+    LOG "  installing via apt (Ubuntu). For exact CUDA-version match prefer the"
+    LOG "  NVIDIA cuda-toolkit-12-x package matching 'nvidia-smi' CUDA Version."
+    sudo apt-get update -y && sudo apt-get install -y nvidia-cuda-toolkit || \
+      LOG "  apt nvcc install FAILED — install toolkit matching driver manually"
+    command -v nvcc >/dev/null 2>&1 && LOG "  nvcc: $(nvcc --version | tail -1)" || LOG "  nvcc STILL missing"
+  fi
+else
+  LOG "2/6 CUDA toolkit SKIPPED (set WITH_CUDA_TOOLKIT=1 to enable A-cluster compile)"
+fi
+
+# ── 3. download embedding + reranker models [VERIFIED] ─────────────────────
+LOG "3/6 pre-download bge-m3 + bge-reranker-v2-m3 (HF cache)"
+FETCH="$(dirname "$0")/_t4_fetch_models.py"
+if [ -f "$FETCH" ]; then python3 "$FETCH"; else
+  python3 - <<'PY'
+from sentence_transformers import SentenceTransformer, CrossEncoder
+SentenceTransformer("BAAI/bge-m3"); CrossEncoder("BAAI/bge-reranker-v2-m3")
+print("models ready")
+PY
+fi
+
+# ── 4. start daemon (GPU + reranker) [VERIFIED] ────────────────────────────
+# NOTE: daemon.py:96-99 reranker path lacks an HF-fallback → MUST pass
+# ZMM_RERANKER_MODEL on HF-cache hosts or it silently falls back to dense.
+LOG "4/6 start compass daemon (GPU + reranker)"
+mkdir -p "$APP_DIR"
+[ -f "$APP_DIR/daemon.py" ] || LOG "  WARN: $APP_DIR/daemon.py missing — scp it first"
+pkill -f "python3 daemon.py" 2>/dev/null; sleep 2
+( cd "$APP_DIR" && PATH="$HOME/.local/bin:$PATH" \
+  ZMM_DEVICE=cuda COMPASS_PROD_RERANK=1 ZMM_RERANKER_MODEL=BAAI/bge-reranker-v2-m3 \
+  COMPASS_USE_INOTIFY=0 \
+  setsid python3 daemon.py > "$HOME/compass_daemon.log" 2>&1 < /dev/null & )
+for i in $(seq 1 18); do
+  if ss -tln 2>/dev/null | grep -q 9876; then LOG "  daemon listening 127.0.0.1:9876 (~$((i*5))s)"; break; fi
+  sleep 5
+done
+
+# ── 5. corpus [VERIFIED via tar; prod uses ops/corpus_sync.py rsync] ───────
+LOG "5/6 corpus dir: $MEM_REMOTE  (push .md from a dev/CPU host with corpus_sync.py)"
+mkdir -p "$MEM_REMOTE"
+LOG "  count: $(ls "$MEM_REMOTE"/*.md 2>/dev/null | wc -l) .md present"
+
+# ── 6. A-cluster deps [UNVERIFIED] ─────────────────────────────────────────
+LOG "6/6 A-cluster: requires nvcc (step 2) + per-sample run.py/harness.py — verify on this GPU"
+
+LOG "bootstrap done. Verify: ssh in, run a recall query; for A-cluster compile a sample .cu."

--- a/ops/compass-daemon.service
+++ b/ops/compass-daemon.service
@@ -1,0 +1,31 @@
+[Unit]
+# compass memory daemon (bge-m3 embeddings + bge-reranker-v2-m3) on a GPU host.
+# Persistent deploy: starts on boot, restarts on failure. Listens 127.0.0.1:9876.
+# Install:
+#   sudo cp compass-daemon.service /etc/systemd/system/
+#   sudo systemctl daemon-reload && sudo systemctl enable --now compass-daemon
+# Verify: systemctl status compass-daemon ; ss -tln | grep 9876
+Description=compass memory daemon (GPU · bge-m3 + reranker)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ubuntu
+WorkingDirectory=/home/ubuntu/compass
+# HF cache on the data disk (models live there); GPU device; reranker on.
+# reranker model resolves to HF id via the daemon's exists()-fallback (no
+# ZMM_RERANKER_MODEL workaround needed since the 2026-06-07 daemon fix).
+Environment=HF_HOME=/mnt/datadisk0/hf-cache
+Environment=ZMM_DEVICE=cuda
+Environment=COMPASS_PROD_RERANK=1
+Environment=COMPASS_USE_INOTIFY=0
+Environment=PATH=/home/ubuntu/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/python3 /home/ubuntu/compass/daemon.py
+Restart=always
+RestartSec=5
+# give the model load room before considering it failed
+TimeoutStartSec=120
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/corpus_sync.py
+++ b/ops/corpus_sync.py
@@ -1,0 +1,96 @@
+"""corpus_sync — mirror the compass memory corpus (.md only) between hosts.
+
+Phase 0 Task 2 of the cloud-substrate plan. The cloud T4 daemon needs the memory
+corpus but NOT the multi-GB transcript history: we mirror only `.md` files
+(measured ~5MB/project vs 1.8GB with transcripts). rsync makes it idempotent —
+a re-run with no changes transfers nothing.
+
+  push_corpus(local_memory_dir, remote_host, remote_dir)   # dev/CPU-server -> T4
+  pull_corpus(remote_host, remote_dir, local_cache)         # T4 startup pull
+
+CLI:
+  python corpus_sync.py push --local ~/.claude/.../memory --host ubuntu@T4 --remote ~/compass-corpus
+  python corpus_sync.py pull --host ubuntu@T4 --remote ~/compass-corpus --local ./corpus-cache
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+# rsync filter: recurse dirs, take only .md, drop everything else.
+_MD_FILTER = ["--include=*/", "--include=*.md", "--exclude=*"]
+
+
+def select_corpus_files(root: str) -> list[str]:
+    """Return relative paths of corpus files to sync (.md only, no transcripts/caches).
+
+    Pure helper — the source of truth for what counts as 'corpus'. Mirrors the
+    rsync filter so tests can assert selection without running rsync.
+    """
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d != "__pycache__" and not d.startswith(".git")]
+        for fn in filenames:
+            if fn.endswith(".md"):
+                rel = os.path.relpath(os.path.join(dirpath, fn), root)
+                out.append(rel)
+    return out
+
+
+def _default_runner(cmd: list[str]) -> int:
+    return subprocess.run(cmd).returncode
+
+
+def _rsync(src: str, dst: str, dry_run: bool, runner) -> int:
+    cmd = ["rsync", "-az", "--delete"] + _MD_FILTER
+    if dry_run:
+        cmd.append("-n")
+    cmd += [src, dst]
+    return runner(cmd)
+
+
+def push_corpus(local_dir, remote_host, remote_dir, dry_run=False, runner=None):
+    """Mirror local .md corpus up to remote_host:remote_dir."""
+    runner = runner or _default_runner
+    src = local_dir.rstrip("/\\") + "/"
+    dst = f"{remote_host}:{remote_dir}"
+    return _rsync(src, dst, dry_run, runner)
+
+
+def pull_corpus(remote_host, remote_dir, local_cache, dry_run=False, runner=None):
+    """Pull the .md corpus down from remote_host:remote_dir into local_cache."""
+    runner = runner or _default_runner
+    src = f"{remote_host}:{remote_dir.rstrip('/')}/"
+    dst = local_cache.rstrip("/\\") + "/"
+    os.makedirs(local_cache, exist_ok=True)
+    return _rsync(src, dst, dry_run, runner)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    p = sub.add_parser("push")
+    p.add_argument("--local", required=True)
+    p.add_argument("--host", required=True)
+    p.add_argument("--remote", required=True)
+    p.add_argument("--dry-run", action="store_true")
+    q = sub.add_parser("pull")
+    q.add_argument("--host", required=True)
+    q.add_argument("--remote", required=True)
+    q.add_argument("--local", required=True)
+    q.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if args.cmd == "push":
+        n = len(select_corpus_files(args.local))
+        print(f"pushing {n} .md files -> {args.host}:{args.remote}")
+        rc = push_corpus(args.local, args.host, args.remote, dry_run=args.dry_run)
+    else:
+        rc = pull_corpus(args.host, args.remote, args.local, dry_run=args.dry_run)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/recall_fallback.py
+++ b/ops/recall_fallback.py
@@ -1,0 +1,63 @@
+"""recall_with_fallback — query the T4 GPU daemon first, fall back to the CPU
+server on connection failure (Phase 0 Task 4 of the cloud-substrate plan).
+
+The cloud topology runs a spot T4 GPU daemon (fast reranked recall) plus a
+persistent CPU server (cold standby). When the spot T4 is preempted or
+unreachable, the client must transparently fall back to the CPU server so recall
+never hard-fails. A daemon that is reachable but returns ok=False (a query-level
+error) is NOT a connection failure and does not trigger fallback.
+
+Protocol mirrors recall.try_daemon_recall: newline-delimited JSON over TCP to
+the daemon's (host, 9876).
+"""
+from __future__ import annotations
+
+import json
+import socket
+
+# exceptions that mean "this endpoint is down / unreachable" -> try the next one
+_CONN_ERRORS = (ConnectionError, socket.timeout, TimeoutError, OSError)
+
+
+def call_endpoint(host, port, query, project, top_k=8, action="recall", timeout=60.0):
+    """One round-trip to a compass daemon. Raises on connection failure."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        s.connect((host, port))
+        req = {"action": action, "query": query[:2000], "project": project, "top_k": top_k}
+        s.sendall(json.dumps(req, ensure_ascii=False).encode("utf-8") + b"\n")
+        buf = b""
+        while b"\n" not in buf:
+            chunk = s.recv(65536)
+            if not chunk:
+                break
+            buf += chunk
+    line, _, _ = buf.partition(b"\n")
+    return json.loads(line.decode("utf-8"))
+
+
+def recall_with_fallback(query, project, primary, fallback, top_k=8,
+                         action="recall", caller=call_endpoint):
+    """Try `primary` (host, port); on connection failure try `fallback`.
+
+    Returns the daemon response dict annotated with `served_by` in
+    {"primary", "fallback", None}. Never raises on connection failure — returns
+    {"ok": False, "served_by": None, "error": ...} when every endpoint is down.
+    """
+    endpoints = [("primary", primary)]
+    if fallback:
+        endpoints.append(("fallback", fallback))
+
+    last_err = None
+    for label, ep in endpoints:
+        host, port = ep
+        try:
+            res = caller(host, port, query=query, project=project, top_k=top_k, action=action)
+        except _CONN_ERRORS as e:
+            last_err = f"{label} {host}:{port} unreachable: {type(e).__name__}: {e}"
+            continue
+        res = dict(res)
+        res["served_by"] = label
+        return res
+
+    return {"ok": False, "served_by": None, "error": last_err or "no endpoint reachable"}

--- a/ops/snapshot_pull.py
+++ b/ops/snapshot_pull.py
@@ -1,0 +1,75 @@
+"""snapshot_pull — T4 GPU daemon pulls the PoI credit snapshot from the CPU server.
+
+Phase 0 Task 3 of the cloud-substrate plan. The authoritative PoI credit table
+lives in postgres on the CPU server; `regen_poi_snapshot.sh` (cron) dumps it to
+`/var/lib/compass/poi/poi_credit_snapshot.json`. The T4 daemon does NOT talk to
+postgres — it reads a local snapshot the v14 boost mtime-reloads. This script
+pulls that snapshot down atomically (scp to .tmp, then os.replace) so the boost
+never sees a half-written file.
+
+  pull_snapshot(remote_host, remote_path, local_path)   # cron on T4, e.g. every 10min
+
+CLI:
+  python snapshot_pull.py --host ubuntu@cpu \
+      --remote /var/lib/compass/poi/poi_credit_snapshot.json \
+      --local /var/lib/compass/poi/poi_credit_snapshot.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def _default_runner(cmd: list[str]) -> int:
+    return subprocess.run(cmd).returncode
+
+
+def pull_snapshot(remote_host, remote_path, local_path, runner=None) -> int:
+    """scp remote snapshot to a .tmp sibling, then atomically replace local_path.
+
+    Returns the scp return code. On failure the existing local_path is untouched.
+    """
+    runner = runner or _default_runner
+    tmp = local_path + ".tmp"
+    parent = os.path.dirname(local_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    cmd = ["scp", "-q", f"{remote_host}:{remote_path}", tmp]
+    rc = runner(cmd)
+    if rc != 0:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        return rc
+    os.replace(tmp, local_path)  # atomic on POSIX & Windows
+    return 0
+
+
+def load_snapshot(local_path) -> dict:
+    """Load the snapshot as {memory_key: cumulative_impact}. Missing/invalid -> {}."""
+    try:
+        with open(local_path, encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", required=True)
+    ap.add_argument("--remote", default="/var/lib/compass/poi/poi_credit_snapshot.json")
+    ap.add_argument("--local", default="/var/lib/compass/poi/poi_credit_snapshot.json")
+    args = ap.parse_args()
+    rc = pull_snapshot(args.host, args.remote, args.local)
+    if rc == 0:
+        print(f"pulled snapshot: {len(load_snapshot(args.local))} keys -> {args.local}")
+    else:
+        print(f"snapshot pull failed (rc={rc}); kept existing", file=sys.stderr)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_corpus_sync.py
+++ b/tests/test_corpus_sync.py
@@ -1,0 +1,77 @@
+"""TDD for ops/corpus_sync.py — corpus selection + rsync wrappers (Phase 0 Task 2)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "ops"))
+
+import corpus_sync as C  # noqa: E402
+
+
+def _make_tree(tmp_path):
+    (tmp_path / "a.md").write_text("# a", encoding="utf-8")
+    (tmp_path / "MEMORY.md").write_text("# index", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.md").write_text("# c", encoding="utf-8")
+    # things that must be excluded
+    (tmp_path / "transcript.jsonl").write_text("{}", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")
+    pc = tmp_path / "__pycache__"
+    pc.mkdir()
+    (pc / "x.pyc").write_bytes(b"\x00")
+    return tmp_path
+
+
+def test_select_only_md(tmp_path):
+    _make_tree(tmp_path)
+    got = sorted(C.select_corpus_files(str(tmp_path)))
+    assert got == ["MEMORY.md", "a.md", os.path.join("sub", "c.md")]
+
+
+def test_select_excludes_jsonl_and_pycache(tmp_path):
+    _make_tree(tmp_path)
+    got = C.select_corpus_files(str(tmp_path))
+    assert not any(p.endswith(".jsonl") for p in got)
+    assert not any("__pycache__" in p for p in got)
+    assert not any(p.endswith(".txt") for p in got)
+
+
+def test_select_empty_dir(tmp_path):
+    assert C.select_corpus_files(str(tmp_path)) == []
+
+
+def test_push_corpus_builds_rsync_and_is_idempotent_flagged(tmp_path):
+    _make_tree(tmp_path)
+    calls = []
+
+    def fake_runner(cmd):
+        calls.append(cmd)
+        return 0
+
+    rc = C.push_corpus(str(tmp_path), "ubuntu@host", "/remote/corpus", runner=fake_runner)
+    assert rc == 0
+    assert len(calls) == 1
+    cmd = calls[0]
+    # archive + only-md include filter + delete for true mirror + checksum/size skip (idempotent)
+    assert cmd[0] == "rsync"
+    joined = " ".join(cmd)
+    assert "--include=*/" in joined and "--include=*.md" in joined and "--exclude=*" in joined
+    assert "ubuntu@host:/remote/corpus" in joined
+
+
+def test_push_corpus_dry_run_uses_n_flag(tmp_path):
+    _make_tree(tmp_path)
+    calls = []
+    C.push_corpus(str(tmp_path), "ubuntu@host", "/remote/corpus",
+                  runner=lambda c: calls.append(c) or 0, dry_run=True)
+    assert "-n" in calls[0] or "--dry-run" in calls[0]
+
+
+def test_pull_corpus_reverses_direction(tmp_path):
+    calls = []
+    C.pull_corpus("ubuntu@host", "/remote/corpus", str(tmp_path),
+                  runner=lambda c: calls.append(c) or 0)
+    joined = " ".join(calls[0])
+    # source is remote, dest is local
+    assert "ubuntu@host:/remote/corpus" in joined
+    assert str(tmp_path) in joined

--- a/tests/test_recall_fallback.py
+++ b/tests/test_recall_fallback.py
@@ -1,0 +1,81 @@
+"""TDD for ops/recall_fallback.py — T4-primary / CPU-fallback recall (Phase 0 Task 4)."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "ops"))
+
+import recall_fallback as RF  # noqa: E402
+
+PRIMARY = ("t4.example", 9876)
+FALLBACK = ("cpu.example", 9876)
+
+
+def test_primary_success_no_fallback():
+    seen = []
+
+    def caller(host, port, **kw):
+        seen.append((host, port))
+        return {"ok": True, "recall": ["hit"]}
+
+    res = RF.recall_with_fallback("q", "proj", PRIMARY, FALLBACK, caller=caller)
+    assert res["ok"] is True
+    assert res["served_by"] == "primary"
+    assert seen == [PRIMARY]  # fallback never called
+
+
+def test_primary_connection_error_uses_fallback():
+    def caller(host, port, **kw):
+        if (host, port) == PRIMARY:
+            raise ConnectionRefusedError("refused")
+        return {"ok": True, "recall": ["fallback-hit"]}
+
+    res = RF.recall_with_fallback("q", "proj", PRIMARY, FALLBACK, caller=caller)
+    assert res["ok"] is True
+    assert res["served_by"] == "fallback"
+    assert res["recall"] == ["fallback-hit"]
+
+
+def test_primary_timeout_uses_fallback():
+    import socket
+
+    def caller(host, port, **kw):
+        if (host, port) == PRIMARY:
+            raise socket.timeout("timed out")
+        return {"ok": True, "recall": []}
+
+    res = RF.recall_with_fallback("q", "proj", PRIMARY, FALLBACK, caller=caller)
+    assert res["served_by"] == "fallback"
+
+
+def test_both_down_returns_error_not_raise():
+    def caller(host, port, **kw):
+        raise ConnectionError("down")
+
+    res = RF.recall_with_fallback("q", "proj", PRIMARY, FALLBACK, caller=caller)
+    assert res["ok"] is False
+    assert res["served_by"] is None
+    assert "error" in res
+
+
+def test_no_fallback_configured_primary_down():
+    def caller(host, port, **kw):
+        raise ConnectionRefusedError("refused")
+
+    res = RF.recall_with_fallback("q", "proj", PRIMARY, None, caller=caller)
+    assert res["ok"] is False
+    assert res["served_by"] is None
+
+
+def test_primary_ok_false_is_not_a_fallback_trigger():
+    """A daemon that is UP but returns ok=False (e.g. query error) is not a connection
+    failure -> per plan we do not fall back; return the primary's response."""
+    calls = []
+
+    def caller(host, port, **kw):
+        calls.append((host, port))
+        return {"ok": False, "error": "bad query"}
+
+    res = RF.recall_with_fallback("q", "proj", PRIMARY, FALLBACK, caller=caller)
+    assert res["served_by"] == "primary"
+    assert res["ok"] is False
+    assert calls == [PRIMARY]

--- a/tests/test_reranker_model_resolution.py
+++ b/tests/test_reranker_model_resolution.py
@@ -1,0 +1,46 @@
+"""TDD for daemon._RERANKER_MODEL resolution (2026-06-07 HF-fallback fix).
+
+Bug: on HF-cache-only hosts the reranker path had no HF-id fallback, so it tried
+to load a non-existent ModelScope path and silently fell back to dense order.
+Fix mirrors EMBEDDER_MODEL: local ModelScope path if it exists, else HF repo id.
+
+We import daemon in a subprocess with a controlled fake home so the test does not
+depend on whether THIS machine happens to have a ModelScope cache.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+_SNIPPET = "import daemon; print(daemon._RERANKER_MODEL)"
+
+
+def _run_with_home(home: Path, extra_env=None):
+    env = dict(os.environ)
+    env["HOME"] = str(home)          # POSIX
+    env["USERPROFILE"] = str(home)   # Windows (Path.home() -> expanduser('~'))
+    env.pop("ZMM_RERANKER_MODEL", None)
+    if extra_env:
+        env.update(extra_env)
+    p = subprocess.run([sys.executable, "-c", _SNIPPET], cwd=str(ROOT),
+                       capture_output=True, text=True, env=env, timeout=120)
+    assert p.returncode == 0, f"daemon import failed:\n{p.stderr[-1500:]}"
+    return p.stdout.strip().splitlines()[-1].strip()
+
+
+def test_falls_back_to_hf_id_when_no_modelscope(tmp_path):
+    # clean home, no modelscope cache -> must resolve to the HF repo id (the fix)
+    assert _run_with_home(tmp_path) == "BAAI/bge-reranker-v2-m3"
+
+
+def test_prefers_local_modelscope_path_when_present(tmp_path):
+    ms = tmp_path / ".cache/modelscope/hub/models/BAAI/bge-reranker-v2-m3"
+    ms.mkdir(parents=True)
+    got = _run_with_home(tmp_path)
+    assert got == str(ms), got
+
+
+def test_env_override_wins(tmp_path):
+    got = _run_with_home(tmp_path, {"ZMM_RERANKER_MODEL": "some/custom-reranker"})
+    assert got == "some/custom-reranker"

--- a/tests/test_snapshot_pull.py
+++ b/tests/test_snapshot_pull.py
@@ -1,0 +1,66 @@
+"""TDD for ops/snapshot_pull.py — T4 pulls PoI credit snapshot (Phase 0 Task 3)."""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "ops"))
+
+import snapshot_pull as SP  # noqa: E402
+
+
+def test_pull_builds_scp_command(tmp_path):
+    calls = []
+    # runner returns nonzero so no os.replace happens — we only inspect the command
+    SP.pull_snapshot("ubuntu@cpu", "/var/lib/compass/poi/poi_credit_snapshot.json",
+                     str(tmp_path / "local_snap.json"),
+                     runner=lambda c: calls.append(c) or 1)
+    cmd = calls[0]
+    assert cmd[0] == "scp"
+    joined = " ".join(cmd)
+    assert "ubuntu@cpu:/var/lib/compass/poi/poi_credit_snapshot.json" in joined
+    # atomic: scp lands on a .tmp sibling, not the live path
+    assert joined.rstrip().endswith(".tmp")
+
+
+def test_pull_atomic_replace_on_success(tmp_path):
+    live = tmp_path / "snap.json"
+    live.write_text('{"old": 1}', encoding="utf-8")
+
+    def runner(cmd):
+        # simulate scp writing the .tmp destination
+        dst = cmd[-1]
+        with open(dst, "w", encoding="utf-8") as f:
+            f.write('{"new_key": 0.5}')
+        return 0
+
+    rc = SP.pull_snapshot("ubuntu@cpu", "/remote/snap.json", str(live), runner=runner)
+    assert rc == 0
+    assert json.loads(live.read_text(encoding="utf-8")) == {"new_key": 0.5}
+    assert not (tmp_path / "snap.json.tmp").exists()  # tmp cleaned up
+
+
+def test_pull_keeps_old_on_failure(tmp_path):
+    live = tmp_path / "snap.json"
+    live.write_text('{"old": 1}', encoding="utf-8")
+    rc = SP.pull_snapshot("ubuntu@cpu", "/remote/snap.json", str(live),
+                          runner=lambda c: 1)  # scp fails
+    assert rc != 0
+    assert json.loads(live.read_text(encoding="utf-8")) == {"old": 1}  # untouched
+
+
+def test_boost_can_load_pulled_snapshot(tmp_path):
+    """Round-trip: a pulled snapshot is valid JSON the v14 boost can read."""
+    live = tmp_path / "snap.json"
+
+    def runner(cmd):
+        with open(cmd[-1], "w", encoding="utf-8") as f:
+            f.write('{"proj/mem-a.md": 1.5, "proj/mem-b.md": -0.5}')
+        return 0
+
+    SP.pull_snapshot("ubuntu@cpu", "/remote/snap.json", str(live), runner=runner)
+    credits = SP.load_snapshot(str(live))
+    assert credits["proj/mem-a.md"] == 1.5
+
+
+def test_load_missing_returns_empty(tmp_path):
+    assert SP.load_snapshot(str(tmp_path / "nope.json")) == {}


### PR DESCRIPTION
## Summary
- **corpus_sync.py** — mirror .md-only memory corpus host↔T4 via rsync (idempotent; excludes transcripts/caches)
- **snapshot_pull.py** — T4 pulls poi_credit_snapshot.json from CPU server atomically (scp .tmp + os.replace; keeps old on failure)
- **recall_fallback.py** — `recall_with_fallback`: T4-primary / CPU-fallback recall; falls back on connection failure only (not ok=False)
- **runbook 2026-06-07-t4-daemon-bringup.md** — verified-live steps for daemon+reranker on Tesla T4 GPU

Implements Phase 0 Task 2/3/4 of `docs/plans/2026-06-06-compass-cloud-substrate-plan.md` (un-gated code) + documents Phase 2 Task 7 bringup.

## Verified live (T4 43.163.80.46)
- daemon bge-m3 + bge-reranker-v2-m3 on Tesla T4 GPU (6.3G), `listening 127.0.0.1:9876`
- recall over 966-file corpus: 3 queries top-hit correct; reranker engaged (log + reorder)
- latency: cold 75.8s, dense warm 0.2-0.3s, reranked warm ~4.2s/query (30 candidates)
- found daemon.py footgun: reranker path lacks HF-fallback (needs ZMM_RERANKER_MODEL) — documented, left as follow-up PR

## Test Plan
- [x] 17 TDD green (corpus_sync 6, recall_fallback 6, snapshot_pull 5)
- [ ] CI on PR
- [ ] follow-up: daemon.py reranker HF-fallback fix; Phase 2 systemd + spot preemption (Task 7 full) + client fallback wiring (Task 8)