### PR TITLE
feat(s4): add ExperiencePacket schema for agent harness post-training

### DIFF
--- a/docs/plans/2026-07-30-s4-experience-packet-v0-design.md
+++ b/docs/plans/2026-07-30-s4-experience-packet-v0-design.md
@@ -1,0 +1,46 @@
+# Compass S4 Experience Packet v0 Design
+
+## Goal
+
+Introduce the smallest durable representation of one Agent Harness experience without
+wiring it into storage, daemons, ingestion, PoI reranking, policy mutation, or capsule
+generation.
+
+## Strategic role
+
+An Experience Packet is the SFT-like atomic sample in the Compass S4 post-training
+flywheel. It records what task was attempted, what action and tools were used, what
+happened, and which route or future policy hint may be relevant. Reward and impact
+signals can be attached later. Repeated high-value packets may eventually be distilled
+into memory capsules, but that distillation is deliberately outside this change.
+
+## Schema
+
+`ExperiencePacket` is a frozen dataclass. Every field defaults to `None` so producers can
+adopt the schema incrementally and old call sites remain unaffected. `tool_chain` is held
+as an immutable tuple inside the packet and serialized as a list for frontmatter.
+
+Fields:
+
+- Identity: `episode_id`, `parent_episode_id`
+- Experience: `task`, `action_kind`, `tool_chain`, `outcome`, `failure_mode`
+- Signals: `reward_delta`, `impact`
+- Policy and distillation hints: `route_key`, `capsule_candidate`, `policy_hint`
+
+## Helpers
+
+- `from_args(args=None, **overrides)` reads only schema fields from an argparse namespace
+  or mapping, ignores unrelated source arguments, applies explicit overrides, rejects
+  misspelled explicit fields, and normalizes the tool chain.
+- `to_frontmatter(packet)` returns a plain dictionary, omits fields that are `None`, keeps
+  explicit false and zero values, and converts the tool-chain tuple to a list.
+
+## Compatibility and non-goals
+
+Tool chains accept a single tool name or an ordered sequence of tool names. Unordered,
+binary, or non-string values fail at the schema boundary instead of creating unstable
+training samples.
+
+This module has no side effects and changes no existing interface. It does not alter the
+database, daemon, governance plan, `ingest_obs`, capsule generation, PoI ordering, or model
+weights. Those integrations require separate evidence and promotion gates.

--- a/docs/plans/2026-07-30-s4-experience-packet-v0.md
+++ b/docs/plans/2026-07-30-s4-experience-packet-v0.md
@@ -1,0 +1,93 @@
+# S4 Experience Packet v0 Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a backward-compatible Experience Packet v0 schema and serialization helpers for the Compass S4 Agent Harness post-training flywheel.
+
+**Architecture:** Create one side-effect-free `gep` module containing a frozen dataclass and two module-level helpers. Keep every field optional, serialize only present values, and accept argparse namespaces or mappings without coupling to any runtime writer.
+
+**Tech Stack:** Python 3.10+ dataclasses and typing, pytest, Ruff.
+
+---
+
+### Task 1: Specify the schema behavior with tests
+
+**Files:**
+- Create: `tests/gep/test_experience_packet.py`
+
+**Step 1: Write the failing tests**
+
+Cover all-optional defaults, a complete packet, frontmatter omission of `None`, retention
+of explicit false and zero values, direct-construction immutability, tool-chain
+normalization and rejection boundaries, unrelated argparse fields, explicit overrides,
+misspelled override rejection, and mapping input.
+
+**Step 2: Run the test to verify it fails**
+
+Run: `python -m pytest -q tests/gep/test_experience_packet.py`
+
+Expected: collection fails because `gep.experience_packet` does not exist.
+
+### Task 2: Implement the minimal schema
+
+**Files:**
+- Create: `gep/experience_packet.py`
+- Test: `tests/gep/test_experience_packet.py`
+
+**Step 1: Add `ExperiencePacket`**
+
+Use a frozen dataclass whose twelve requested fields all default to `None`. Represent a
+present tool chain as `tuple[str, ...]`.
+
+**Step 2: Add `from_args`**
+
+Read allowlisted schema fields from an argparse namespace or mapping, ignore unrelated
+source arguments, apply explicit schema-field overrides, reject unknown explicit fields,
+and normalize ordered string tool chains without guessing delimiters.
+
+**Step 3: Add `to_frontmatter`**
+
+Return a new plain dictionary containing only non-`None` values. Convert a tuple tool
+chain to a list while retaining `False`, `0`, and `0.0`.
+
+**Step 4: Run the focused test**
+
+Run: `python -m pytest -q tests/gep/test_experience_packet.py`
+
+Expected: all tests pass.
+
+### Task 3: Verify compatibility and quality
+
+**Files:**
+- Verify: `gep/experience_packet.py`
+- Verify: `tests/gep/test_experience_packet.py`
+
+**Step 1: Run the GEP suite**
+
+Run: `python -m pytest -q tests/gep`
+
+Expected: all existing capsule and PoI tests plus Experience Packet tests pass.
+
+**Step 2: Run static and patch checks**
+
+Run: `python -m ruff check gep/experience_packet.py tests/gep/test_experience_packet.py`
+
+Run: `git diff --check`
+
+Expected: both commands exit successfully.
+
+**Step 3: Review the diff against non-goals**
+
+Confirm that no database, daemon, ingestion, governance, PoI reranking, capsule-generation,
+or model-training file changed.
+
+**Step 4: Commit**
+
+Run:
+
+```bash
+git add docs/plans/2026-07-30-s4-experience-packet-v0-design.md \
+  docs/plans/2026-07-30-s4-experience-packet-v0.md \
+  gep/experience_packet.py tests/gep/test_experience_packet.py
+git commit -m "feat (s4): add Experience Packet schema for agent harness post-training"
+```

--- a/gep/experience_packet.py
+++ b/gep/experience_packet.py
@@ -1,0 +1,98 @@
+"""Experience Packet v0 for the Compass S4 Agent Harness flywheel.
+
+An Experience Packet is a side-effect-free record of one agent episode.  It is the
+atomic, SFT-like sample that later stages may evaluate with reinforcement signals,
+use to update route preferences, or distill into a memory capsule.  This module only
+defines the packet boundary; it does not perform any of those later-stage actions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, fields
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ExperiencePacket:
+    """Optional metadata captured from one agent-harness episode."""
+
+    episode_id: str | None = None
+    parent_episode_id: str | None = None
+    task: str | None = None
+    action_kind: str | None = None
+    tool_chain: Sequence[str] | None = None
+    outcome: str | None = None
+    failure_mode: str | None = None
+    reward_delta: float | None = None
+    impact: float | None = None
+    route_key: str | None = None
+    capsule_candidate: bool | None = None
+    policy_hint: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tool_chain", _normalize_tool_chain(self.tool_chain))
+
+
+_FIELD_NAMES = tuple(field.name for field in fields(ExperiencePacket))
+
+
+def _normalize_tool_chain(value: Any) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, Sequence) or isinstance(value, (bytes, bytearray)):
+        raise TypeError("tool_chain must be a string or ordered sequence of strings")
+    normalized = tuple(value)
+    if any(not isinstance(tool, str) for tool in normalized):
+        raise TypeError("tool_chain must be a string or ordered sequence of strings")
+    return normalized
+
+
+def from_args(
+    args: Mapping[str, Any] | object | None = None,
+    **overrides: Any,
+) -> ExperiencePacket:
+    """Build a packet from argparse-style arguments or a mapping.
+
+    Only Experience Packet fields are read.  Unrelated arguments are ignored so a
+    caller can pass an existing ``argparse.Namespace`` without changing its parser.
+    Explicit keyword values override values read from ``args``.
+    """
+
+    if args is None:
+        source: Mapping[str, Any] = {}
+    elif isinstance(args, Mapping):
+        source = args
+    else:
+        try:
+            source = vars(args)
+        except TypeError as exc:
+            raise TypeError("args must be a mapping, namespace-like object, or None") from exc
+
+    unknown_overrides = sorted(set(overrides) - set(_FIELD_NAMES))
+    if unknown_overrides:
+        label = "field" if len(unknown_overrides) == 1 else "fields"
+        names = ", ".join(unknown_overrides)
+        raise TypeError(f"unknown Experience Packet {label}: {names}")
+
+    values = {name: source[name] for name in _FIELD_NAMES if name in source}
+    values.update(overrides)
+    return ExperiencePacket(**values)
+
+
+def to_frontmatter(packet: ExperiencePacket) -> dict[str, Any]:
+    """Return frontmatter-ready metadata, omitting fields that were not supplied."""
+
+    frontmatter = {
+        name: getattr(packet, name)
+        for name in _FIELD_NAMES
+        if getattr(packet, name) is not None
+    }
+    if "tool_chain" in frontmatter:
+        frontmatter["tool_chain"] = list(frontmatter["tool_chain"])
+    return frontmatter
+
+
+__all__ = ["ExperiencePacket", "from_args", "to_frontmatter"]

--- a/tests/gep/test_experience_packet.py
+++ b/tests/gep/test_experience_packet.py
@@ -1,0 +1,158 @@
+from argparse import Namespace
+from dataclasses import FrozenInstanceError, fields
+
+import pytest
+
+from gep.experience_packet import ExperiencePacket, from_args, to_frontmatter
+
+EXPECTED_FIELDS = (
+    "episode_id",
+    "parent_episode_id",
+    "task",
+    "action_kind",
+    "tool_chain",
+    "outcome",
+    "failure_mode",
+    "reward_delta",
+    "impact",
+    "route_key",
+    "capsule_candidate",
+    "policy_hint",
+)
+
+
+def test_all_fields_are_optional():
+    packet = ExperiencePacket()
+
+    assert tuple(field.name for field in fields(packet)) == EXPECTED_FIELDS
+    assert all(getattr(packet, name) is None for name in EXPECTED_FIELDS)
+
+
+def test_packet_is_immutable():
+    packet = ExperiencePacket(episode_id="episode-1")
+
+    with pytest.raises(FrozenInstanceError):
+        packet.episode_id = "episode-2"
+
+
+def test_direct_construction_normalizes_tool_chain_to_immutable_tuple():
+    tools = ["search", "verify"]
+    packet = ExperiencePacket(tool_chain=tools)
+    tools.append("mutate_after_construction")
+
+    assert packet.tool_chain == ("search", "verify")
+
+
+def test_to_frontmatter_serializes_complete_packet():
+    packet = ExperiencePacket(
+        episode_id="episode-2",
+        parent_episode_id="episode-1",
+        task="Diagnose a failing retrieval route",
+        action_kind="tool_assisted_diagnosis",
+        tool_chain=("recall", "inspect_trace", "run_test"),
+        outcome="fixed",
+        failure_mode="stale_route",
+        reward_delta=0.75,
+        impact=1.25,
+        route_key="retrieval/diagnosis",
+        capsule_candidate=True,
+        policy_hint="prefer trace inspection before route mutation",
+    )
+
+    assert to_frontmatter(packet) == {
+        "episode_id": "episode-2",
+        "parent_episode_id": "episode-1",
+        "task": "Diagnose a failing retrieval route",
+        "action_kind": "tool_assisted_diagnosis",
+        "tool_chain": ["recall", "inspect_trace", "run_test"],
+        "outcome": "fixed",
+        "failure_mode": "stale_route",
+        "reward_delta": 0.75,
+        "impact": 1.25,
+        "route_key": "retrieval/diagnosis",
+        "capsule_candidate": True,
+        "policy_hint": "prefer trace inspection before route mutation",
+    }
+
+
+def test_to_frontmatter_omits_none_but_keeps_explicit_zero_and_false():
+    packet = ExperiencePacket(
+        reward_delta=0.0,
+        impact=0.0,
+        capsule_candidate=False,
+    )
+
+    assert to_frontmatter(packet) == {
+        "reward_delta": 0.0,
+        "impact": 0.0,
+        "capsule_candidate": False,
+    }
+
+
+def test_from_args_accepts_namespace_and_ignores_unrelated_fields():
+    args = Namespace(
+        episode_id="episode-3",
+        tool_chain=["search", "verify"],
+        route_key="research/verify",
+        verbose=True,
+    )
+
+    packet = from_args(args)
+
+    assert packet.episode_id == "episode-3"
+    assert packet.tool_chain == ("search", "verify")
+    assert packet.route_key == "research/verify"
+    assert not hasattr(packet, "verbose")
+
+
+def test_from_args_accepts_mapping_and_explicit_overrides():
+    packet = from_args(
+        {
+            "episode_id": "episode-4",
+            "outcome": "retry",
+            "unknown_future_field": "ignored",
+        },
+        outcome="succeeded",
+        impact=2,
+    )
+
+    assert packet == ExperiencePacket(
+        episode_id="episode-4",
+        outcome="succeeded",
+        impact=2,
+    )
+
+
+def test_from_args_treats_a_string_tool_as_one_tool():
+    packet = from_args({"tool_chain": "single_tool"})
+
+    assert packet.tool_chain == ("single_tool",)
+
+
+def test_from_args_with_no_values_or_none_tool_chain_is_empty():
+    assert from_args() == ExperiencePacket()
+    assert from_args({"tool_chain": None}) == ExperiencePacket()
+
+
+def test_from_args_rejects_values_that_are_not_namespace_like():
+    with pytest.raises(TypeError, match="mapping, namespace-like object, or None"):
+        from_args(42)
+
+
+def test_from_args_rejects_unknown_explicit_override():
+    with pytest.raises(TypeError, match="unknown Experience Packet field: policy_hnit"):
+        from_args(policy_hnit="typo must not disappear")
+
+
+@pytest.mark.parametrize(
+    "tool_chain",
+    [
+        {"search", "verify"},
+        {"first": "search"},
+        b"search",
+        ["search", 7],
+    ],
+)
+def test_tool_chain_rejects_unordered_or_non_string_values(tool_chain):
+    with pytest.raises(TypeError, match="tool_chain must be a string or ordered sequence"):
+        ExperiencePacket(tool_chain=tool_chain)


### PR DESCRIPTION
## Summary

本 PR 引入 Experience Packet 作为 Compass S4 后训练飞轮的原子训练单元，用于承载任务、行为、工具链、结果、奖励和路径等元数据，为后续蒸馏记忆胶囊和策略更新打基础。

- 添加全部字段可选的 `ExperiencePacket` frozen dataclass
- 添加 `from_args` 与 `to_frontmatter` 辅助函数
- 工具链在 schema 边界归一化为不可变 tuple，并拒绝无序或非字符串输入
- 保持独立、无副作用，不接数据库、daemon、`ingest_obs`、PoI 重排序或胶囊生成

## Tests

- `python -m pytest -q tests/gep` — 28 passed (Python 3.13)
- `uv run --no-project --isolated --python 3.10 --with pytest python -m pytest -q tests/gep` — 28 passed
- Experience Packet focused coverage — 100% (15 tests, Python 3.10)
- `uvx ruff check gep/experience_packet.py tests/gep/test_experience_packet.py` — passed
- `git diff --cached --check` — passed

## Local baseline notes

Full-suite collection is independently blocked by the pre-existing external file `C:\Users\chunx\.claude\hooks\inbound_outbound_surface.py` being absent. With that test ignored, 1076 tests pass; one HTTP test and two recall-semantic setup cases require the separately missing `python-jose` dependency. No workaround or unrelated dependency change is included in this PR.

## Non-goals

No capsule generation, PoI reranking, governance-plan change, runtime ingestion wiring, database migration, daemon change, or model training.