### PR TITLE
fix(ci): pin Ruff lint baseline

### DIFF
--- a/ops/_verify_retrieve_gpu.py
+++ b/ops/_verify_retrieve_gpu.py
@@ -5,7 +5,7 @@
 一个 DIVERSE 多主题避坑语料,证实它按 query 召回最相关原子(替裸 cat)+ 计时。
 裸 cat 会把全部 8 原子塞进 context;检索只挑相关的。
 """
-import os, time
+import time
 import autolab_corpus_retrieve as r
 
 DIVERSE = """# 避坑语料 · autolab/radix_sort_demo

--- a/ops/autolab_eval.py
+++ b/ops/autolab_eval.py
@@ -10,7 +10,7 @@
   python3 autolab_eval.py --task radix_sort --candidate path/to/solve.c [--trials 3] [--json out.json]
 约束:v1 支持 runtime_seconds 类(系统优化·候选=solve.c)。其他 metric 类(comparator/cycles/params)TODO。
 """
-import argparse, json, math, os, shutil, subprocess, sys, tempfile, tomllib
+import argparse, json, math, os, shutil, subprocess, tempfile, tomllib
 
 AUTOLAB = os.environ.get("AUTOLAB_DIR", "/mnt/datadisk0/autolab")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ extend-exclude = [
 # Default ruff = pyflakes (F) + pycodestyle errors (E)
 # We disable the legacy-style E rules that conflict with the project's
 # compact one-line style; we keep the bug-catching F rules.
+select = ["E4", "E7", "E9", "F"]
 ignore = [
     "E701",  # multiple statements on one line (colon) · used in compact one-liners
     "E702",  # multiple statements on one line (semicolon) · same

--- a/tests/hooks/test_inbound_select.py
+++ b/tests/hooks/test_inbound_select.py
@@ -5,7 +5,6 @@ surface-once 丢失)。纯函数 select_inbound 把"近期未消费"的也二次
 导入全局 hook 文件(~/.claude/hooks/inbound_outbound_surface.py)测其 select_inbound。
 """
 import sys
-import os
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_autolab_corpus_retrieve.py
+++ b/tests/test_autolab_corpus_retrieve.py
@@ -13,7 +13,6 @@ the real bge-m3 + reranker path is verified on the GPU separately.
 """
 from __future__ import annotations
 
-import math
 import sys
 from pathlib import Path
 

--- a/tests/test_liveness_audit.py
+++ b/tests/test_liveness_audit.py
@@ -8,8 +8,6 @@ import sys
 import time
 from pathlib import Path
 
-import pytest
-
 # 加 worktree root 到 sys.path · 方便 import ops.liveness_audit
 _HERE = Path(__file__).resolve().parent
 _ROOT = _HERE.parent


### PR DESCRIPTION
Summary: pin Ruff to the repository documented E/F lint contract; remove five pre-existing unused imports; keep PR-S4-1 schema-only. Verification: full Ruff passed; 18 targeted tests passed; py_compile passed; git diff check passed. Known unrelated baseline: tests/hooks/test_inbound_select.py cannot collect locally because the repository-external hook file is absent; this PR does not create or modify that hook.