### PR TITLE
feat(s4): add append-only flywheel event log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,16 @@ jobs:
           "$RUNNER_TEMP/gep-wheel-smoke/bin/python" -I -c \
             "import gep.experience_packet, gep.flywheel_event, gep.flywheel_log"
 
+  s4-gep-py39:
+    name: S4 GEP minimum Python (3.9)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.9" }
+      - run: pip install pytest
+      - run: python -m pytest -q tests/gep
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,17 @@ jobs:
       - name: GEP flywheel tests
         run: python -m pytest -q tests/gep
 
+      - name: Wheel packaging smoke
+        if: matrix.os == 'ubuntu-latest' && matrix.python == '3.12'
+        run: |
+          python -m pip install build
+          python -m build --wheel --outdir dist
+          python -m venv "$RUNNER_TEMP/gep-wheel-smoke"
+          "$RUNNER_TEMP/gep-wheel-smoke/bin/python" -m pip install --no-deps dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$RUNNER_TEMP/gep-wheel-smoke/bin/python" -I -c \
+            "import gep.experience_packet, gep.flywheel_event, gep.flywheel_log"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,11 +144,11 @@ jobs:
       - uses: actions/setup-python@v5
         with: { python-version: "3.12" }
       - run: pip install -e . pytest
-      - name: MCP + A2A protocol unit tests
+      - name: MCP + A2A + GEP unit tests
         env:
           PYTHONIOENCODING: utf-8
           PYTHONUTF8: "1"
-        run: pytest tests/test_mcp_server.py tests/test_a2a_adapter.py tests/test_merkle_chain.py -q
+        run: pytest tests/test_mcp_server.py tests/test_a2a_adapter.py tests/test_merkle_chain.py tests/gep -q
 
   v10-v7-governance-smoke:
     name: v1.0 V7 governance demo (lock+dispatch+audit)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install -e .[modelscope,fast-download]
+          pip install -e .[modelscope,fast-download] pytest
           # 用 small-zh 跑 CI · 比 m3 快 20x · 内存 < 200MB
           python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('BAAI/bge-small-zh-v1.5')"
 
@@ -53,6 +53,9 @@ jobs:
           assert auc >= 0.65, f'AUC regression: {auc}'
           print(f'AUC OK: {auc}')
           "
+
+      - name: GEP flywheel tests
+        run: python -m pytest -q tests/gep
 
   lint:
     name: Lint

--- a/docs/plans/2026-07-31-s4-flywheel-event-log-design.md
+++ b/docs/plans/2026-07-31-s4-flywheel-event-log-design.md
@@ -1,0 +1,123 @@
+# Compass S4 Flywheel Event Log Design
+
+## Goal
+
+Turn `ExperiencePacket` into the first durable input of the Compass S4 external
+post-training flywheel without building a mutable workflow engine. The runtime
+boundary is one strict, immutable event protocol. Every later stage will emit a
+new linked event instead of editing earlier experience.
+
+This change implements only `episode` admission. Verdict, policy preference,
+capsule, and replay events are later PRs.
+
+## Why an append-only event log
+
+The flywheel is heterogeneous: episodes may come from robot harnesses, software
+tests, FDE tasks, simulations, or authenticated human workflows. They should not
+need separate storage contracts. A stable event envelope is the narrow waist:
+
+```text
+episode -> verdict -> policy_preference -> capsule -> replay_episode
+```
+
+The output of one stage becomes the input of the next. History is never
+overwritten, so reward changes, repairs, forgetting, and promotion decisions keep
+their lineage. SQLite supplies transactions, uniqueness, and restart durability;
+it is not the business workflow or the source of inferred rewards.
+
+## Event envelope v1
+
+`FlywheelEvent` is immutable and accepts an exact allowlist of fields:
+
+- `schema_version`: exactly `compass.flywheel.event.v1`
+- `event_kind`: exactly `episode` in this PR
+- `source_event_id`: stable non-empty producer identifier
+- `episode_id`: stable non-empty episode identifier
+- `parent_event_id`: optional lineage identifier
+- `agent_id`: positive integer; booleans are rejected
+- `occurred_at`: timezone-aware RFC 3339 UTC timestamp ending in `Z`
+- `payload_schema`: exactly `compass.experience_packet.v0`
+- `payload`: strict `ExperiencePacket` frontmatter
+- `payload_hash`: `sha256:<64 lowercase hex>` over canonical payload JSON
+
+The payload must contain `episode_id`, and it must equal the envelope's
+`episode_id`. Unknown envelope or payload fields fail closed. Canonical JSON uses
+UTF-8, sorted keys, compact separators, and rejects NaN/Infinity. `event_hash` is
+derived from the canonical normalized envelope and is not trusted from input.
+
+The envelope references executable policies and evidence by hashes in future
+schemas; it never executes arbitrary code. Code-as-policy artifacts belong in a
+sandboxed artifact store with explicit tool and skill versions.
+
+## Admission and idempotency
+
+`CompassS4AgentHarness` is a thin deterministic adapter around `FlywheelEventLog`.
+It receives structured mappings from registered runtimes and never imports chat,
+Codex, Claude, Feishu, or robot SDK code.
+
+Admission returns an immutable receipt with one of four statuses:
+
+- `accepted`: a new valid event was appended
+- `duplicate`: the same `source_event_id` and `event_hash` already exist
+- `conflict`: the same `source_event_id` refers to different content
+- `quarantined`: schema, hash, timestamp, payload, or agent registration failed
+
+The log receives a set of registered integer agent IDs from its caller. It does
+not create another agent registry. Replaying a valid event is idempotent; existing
+bytes are never overwritten.
+
+## Storage
+
+The SQLite file contains two append-only tables:
+
+1. `flywheel_events`: accepted canonical envelopes, keyed by
+   `source_event_id`, with a unique `event_hash`.
+2. `flywheel_quarantine`: safe rejection receipts containing reason code,
+   source identifier when safely available, and a fingerprint. Raw unknown input
+   is not persisted because it may contain credentials, links, or personal data.
+
+Writes use explicit transactions. The database is reopened in restart tests to
+prove persistence. No mutable `pending/finalized/failed` column is added.
+
+## Pure reducer
+
+Runtime state is a derived view, not a mutable source of truth. The first reducer
+maps admitted `episode` events to `awaiting_verdict`. Later PRs will extend the
+same pure function for linked verdict and promotion events. Given the same ordered
+events, it must always return the same state.
+
+## Failure handling
+
+- Invalid schema or unknown keys: quarantine with `invalid_schema`.
+- Payload hash mismatch: quarantine with `payload_hash_mismatch`.
+- Unregistered agent: quarantine with `unregistered_agent`.
+- Existing source ID with different content: quarantine receipt plus `conflict`.
+- Duplicate content: return `duplicate`; do not append another event.
+- SQLite failure: raise; never report acceptance without a committed row.
+
+## Security and trust boundary
+
+An action-producing agent may submit an episode, but it cannot assign its own
+verdict, PoI, capsule promotion, or routing preference. `capsule_candidate` remains
+an observation-level hint only; independent later gates decide promotion.
+
+Physical verification will be treated as strong external evidence, not infallible
+truth. Sensor, calibration, verifier-version, and environment lineage belong in
+later verdict events.
+
+## Acceptance
+
+- Replaying one valid event 100 times produces one accepted row.
+- Reopening the database preserves canonical bytes, hashes, and derived state.
+- Same source ID with different content cannot overwrite the original.
+- Invalid, hash-mismatched, and unregistered events leave safe quarantine receipts.
+- A one-shot harness fixture completes without chat/runtime framework imports.
+- Focused GEP tests, full GEP tests, Ruff, and `git diff --check` pass.
+
+## Non-goals
+
+- No daemon, scheduler, network listener, or chat dependency.
+- No `ingest_obs` integration or existing governance changes.
+- No verifier/evaluator join, PoI calculation, reward inference, policy mutation,
+  capsule generation, skill execution, Merkle tree, world model, or model training.
+- No Feishu, FDE, robot, or buyer-system writes.

--- a/docs/plans/2026-07-31-s4-flywheel-event-log.md
+++ b/docs/plans/2026-07-31-s4-flywheel-event-log.md
@@ -1,0 +1,307 @@
+# Compass S4 Flywheel Event Log Implementation Plan
+
+> **For Codex:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Admit strict ExperiencePacket episode events into an append-only, idempotent SQLite log with safe quarantine receipts and a deterministic derived-state reducer.
+
+**Architecture:** `gep.flywheel_event` owns canonical serialization, hashes, and fail-closed envelope validation. `gep.flywheel_log` owns transactional append, duplicate/conflict/quarantine receipts, restart-safe reads, the thin `CompassS4AgentHarness`, and a pure episode-state reducer. SQLite is an immutable event log, not a mutable workflow engine.
+
+**Tech Stack:** Python 3.10+ standard library (`dataclasses`, `datetime`, `hashlib`, `json`, `sqlite3`), pytest, Ruff.
+
+---
+
+### Task 1: Specify and implement the strict FlywheelEvent envelope
+
+**Files:**
+- Create: `tests/gep/test_flywheel_event.py`
+- Create: `gep/flywheel_event.py`
+
+**Step 1: Write the failing envelope tests**
+
+Cover:
+
+- a valid `episode` mapping round-trips through canonical normalized JSON;
+- `payload_hash` is SHA-256 over canonical ExperiencePacket payload bytes;
+- `event_hash` is deterministic and derived rather than accepted from input;
+- unknown envelope and payload keys fail closed;
+- wrong schema/event kind/payload schema fail closed;
+- empty IDs, bool/non-positive `agent_id`, non-UTC timestamps, malformed hashes,
+  payload/envelope episode mismatch, NaN, and hash mismatch are rejected;
+- input mappings and nested payloads are copied so later caller mutation cannot
+  alter the event.
+
+Use a helper resembling:
+
+```python
+def valid_mapping(**overrides):
+    payload = {"episode_id": "episode-1", "task": "verify a fix"}
+    event = {
+        "schema_version": "compass.flywheel.event.v1",
+        "event_kind": "episode",
+        "source_event_id": "source-1",
+        "episode_id": "episode-1",
+        "parent_event_id": None,
+        "agent_id": 7,
+        "occurred_at": "2026-07-31T12:00:00Z",
+        "payload_schema": "compass.experience_packet.v0",
+        "payload": payload,
+        "payload_hash": hash_payload(payload),
+    }
+    event.update(overrides)
+    return event
+```
+
+**Step 2: Run tests to verify RED**
+
+Run:
+
+```text
+python -m pytest -q tests/gep/test_flywheel_event.py
+```
+
+Expected: collection fails because `gep.flywheel_event` does not exist.
+
+**Step 3: Implement the minimal envelope**
+
+Add:
+
+```python
+SCHEMA_VERSION = "compass.flywheel.event.v1"
+PAYLOAD_SCHEMA = "compass.experience_packet.v0"
+EVENT_KIND_EPISODE = "episode"
+
+class FlywheelEventError(ValueError):
+    def __init__(self, reason_code: str, message: str): ...
+
+@dataclass(frozen=True)
+class FlywheelEvent:
+    schema_version: str
+    event_kind: str
+    source_event_id: str
+    episode_id: str
+    parent_event_id: str | None
+    agent_id: int
+    occurred_at: str
+    payload_schema: str
+    payload: Mapping[str, Any]
+    payload_hash: str
+
+    @property
+    def event_hash(self) -> str: ...
+
+    def to_mapping(self) -> dict[str, Any]: ...
+```
+
+Add `hash_payload`, `canonical_payload_bytes`, `canonical_event_bytes`, and
+`event_from_mapping`. Use `ExperiencePacket(**payload)` plus `to_frontmatter` to
+normalize and strictly reject unknown payload fields. Require payload
+`episode_id` to be present and equal the envelope value. Use `MappingProxyType`
+or an immutable copied representation internally.
+
+**Step 4: Run tests to verify GREEN**
+
+Run:
+
+```text
+python -m pytest -q tests/gep/test_flywheel_event.py
+```
+
+Expected: all envelope tests pass.
+
+**Step 5: Commit**
+
+```text
+git add gep/flywheel_event.py tests/gep/test_flywheel_event.py
+git commit -m "feat(s4): add strict flywheel episode envelope"
+```
+
+### Task 2: Specify and implement append-only SQLite admission
+
+**Files:**
+- Create: `tests/gep/test_flywheel_log.py`
+- Create: `gep/flywheel_log.py`
+
+**Step 1: Write failing log tests**
+
+Cover:
+
+- first valid event returns `accepted` and inserts one row;
+- 100 replays return one `accepted`, then 99 `duplicate`, and one row total;
+- reopening the database preserves canonical envelope bytes and event hash;
+- same source ID with changed content returns `conflict` and cannot overwrite;
+- same episode ID under a different source returns `conflict`;
+- unregistered agent returns `quarantined` with reason `unregistered_agent`;
+- invalid schema and payload hash mismatch create safe quarantine receipts;
+- quarantine rows contain no raw payload, task, link, password, or unknown key;
+- a SQLite write failure raises rather than returning acceptance.
+
+**Step 2: Run tests to verify RED**
+
+Run:
+
+```text
+python -m pytest -q tests/gep/test_flywheel_log.py
+```
+
+Expected: collection fails because `gep.flywheel_log` does not exist.
+
+**Step 3: Implement receipts and tables**
+
+Add:
+
+```python
+@dataclass(frozen=True)
+class AppendReceipt:
+    status: Literal["accepted", "duplicate", "conflict", "quarantined"]
+    source_event_id: str | None
+    episode_id: str | None
+    event_hash: str | None
+    reason_code: str | None = None
+
+class FlywheelEventLog:
+    def __init__(self, path, registered_agent_ids): ...
+    def append(self, raw_event: Mapping[str, Any]) -> AppendReceipt: ...
+    def get(self, source_event_id: str) -> FlywheelEvent | None: ...
+    def list_events(self) -> tuple[FlywheelEvent, ...]: ...
+    def count_events(self) -> int: ...
+    def list_quarantine(self) -> tuple[dict[str, Any], ...]: ...
+    def close(self) -> None: ...
+```
+
+Create `flywheel_events` with unique `source_event_id` and `episode_id`, storing
+canonical envelope JSON and derived event hash. Create `flywheel_quarantine`
+with only reason, safe source/episode IDs, fingerprint, and timestamp. Use
+explicit transactions and never update accepted rows.
+
+**Step 4: Run tests to verify GREEN**
+
+Run:
+
+```text
+python -m pytest -q tests/gep/test_flywheel_log.py
+```
+
+Expected: all log tests pass.
+
+**Step 5: Commit**
+
+```text
+git add gep/flywheel_log.py tests/gep/test_flywheel_log.py
+git commit -m "feat(s4): persist idempotent flywheel event log"
+```
+
+### Task 3: Add the thin harness and pure reducer
+
+**Files:**
+- Modify: `gep/flywheel_log.py`
+- Modify: `tests/gep/test_flywheel_log.py`
+
+**Step 1: Write failing harness and reducer tests**
+
+Cover:
+
+- `CompassS4AgentHarness.record(mapping)` delegates to the log and returns its
+  immutable receipt;
+- a one-shot fixture records and reads one episode without chat or runtime
+  framework imports;
+- `reduce_episode_states(events)` returns `awaiting_verdict` with episode,
+  source, and event hash lineage;
+- reducer output is deterministic and does not mutate inputs;
+- empty input returns an empty mapping.
+
+**Step 2: Run focused tests to verify RED**
+
+Run:
+
+```text
+python -m pytest -q tests/gep/test_flywheel_log.py -k "harness or reducer"
+```
+
+Expected: failures because harness/reducer names do not exist.
+
+**Step 3: Implement minimal harness and reducer**
+
+Add:
+
+```python
+@dataclass(frozen=True)
+class EpisodeState:
+    episode_id: str
+    state: Literal["awaiting_verdict"]
+    source_event_id: str
+    event_hash: str
+
+class CompassS4AgentHarness:
+    def __init__(self, event_log: FlywheelEventLog): ...
+    def record(self, raw_event: Mapping[str, Any]) -> AppendReceipt: ...
+
+def reduce_episode_states(events: Iterable[FlywheelEvent]) -> dict[str, EpisodeState]: ...
+```
+
+Do not add scheduling, callbacks, network I/O, or policy actions.
+
+**Step 4: Run tests to verify GREEN**
+
+Run:
+
+```text
+python -m pytest -q tests/gep/test_flywheel_log.py
+```
+
+Expected: all log, harness, and reducer tests pass.
+
+**Step 5: Commit**
+
+```text
+git add gep/flywheel_log.py tests/gep/test_flywheel_log.py
+git commit -m "feat(s4): add deterministic harness and episode reducer"
+```
+
+### Task 4: Verify scope, compatibility, and quality
+
+**Files:**
+- Verify: `gep/experience_packet.py`
+- Verify: `gep/flywheel_event.py`
+- Verify: `gep/flywheel_log.py`
+- Verify: `tests/gep/test_flywheel_event.py`
+- Verify: `tests/gep/test_flywheel_log.py`
+
+**Step 1: Run focused and full GEP tests**
+
+```text
+python -m pytest -q tests/gep/test_flywheel_event.py tests/gep/test_flywheel_log.py
+python -m pytest -q tests/gep
+```
+
+Expected: all pass.
+
+**Step 2: Run static checks**
+
+```text
+uvx --offline ruff check gep/flywheel_event.py gep/flywheel_log.py tests/gep/test_flywheel_event.py tests/gep/test_flywheel_log.py
+git diff --check origin/main...HEAD
+```
+
+Expected: both pass.
+
+**Step 3: Review non-goals**
+
+Confirm the diff does not touch daemon, scheduler, `ingest_obs`, PoI, recall,
+capsule generation, governance, Feishu, FDE, robot execution, or model training.
+
+**Step 4: Run a fresh-process restart replay**
+
+Create a temporary database, record one event in one Python process, reopen it in
+a second process, and assert the same canonical envelope and event hash are read.
+
+Expected: one accepted event, no duplicate bytes, deterministic reducer state.
+
+**Step 5: Prepare PR**
+
+```text
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: only the design, plan, event/log modules, and focused tests differ from
+main.

--- a/gep/experience_packet.py
+++ b/gep/experience_packet.py
@@ -8,6 +8,7 @@ defines the packet boundary; it does not perform any of those later-stage action
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, fields
 from typing import Any
@@ -31,10 +32,54 @@ class ExperiencePacket:
     policy_hint: str | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "tool_chain", _normalize_tool_chain(self.tool_chain))
+        for field_name in _STRING_FIELD_NAMES:
+            _validate_optional_string(field_name, getattr(self, field_name))
+        _validate_capsule_candidate(self.capsule_candidate)
+
+        normalized_tool_chain = _normalize_tool_chain(self.tool_chain)
+        normalized_reward_delta = _normalize_metric("reward_delta", self.reward_delta)
+        normalized_impact = _normalize_metric("impact", self.impact)
+
+        object.__setattr__(self, "tool_chain", normalized_tool_chain)
+        object.__setattr__(self, "reward_delta", normalized_reward_delta)
+        object.__setattr__(self, "impact", normalized_impact)
 
 
 _FIELD_NAMES = tuple(field.name for field in fields(ExperiencePacket))
+_STRING_FIELD_NAMES = (
+    "episode_id",
+    "parent_episode_id",
+    "task",
+    "action_kind",
+    "outcome",
+    "failure_mode",
+    "route_key",
+    "policy_hint",
+)
+
+
+def _validate_optional_string(field_name: str, value: Any) -> None:
+    if value is not None and not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string or None")
+
+
+def _validate_capsule_candidate(value: Any) -> None:
+    if value is not None and not isinstance(value, bool):
+        raise TypeError("capsule_candidate must be a bool or None")
+
+
+def _normalize_metric(field_name: str, value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{field_name} must be an int, float, or None")
+    try:
+        normalized = float(value)
+    except OverflowError as exc:
+        raise ValueError(f"{field_name} must be finite") from exc
+    if not math.isfinite(normalized):
+        raise ValueError(f"{field_name} must be finite")
+    return normalized
 
 
 def _normalize_tool_chain(value: Any) -> tuple[str, ...] | None:

--- a/gep/flywheel_event.py
+++ b/gep/flywheel_event.py
@@ -1,0 +1,272 @@
+"""Strict, canonical episode envelope for the Compass S4 flywheel."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, fields
+from datetime import datetime
+from types import MappingProxyType
+from typing import Any
+
+from gep.experience_packet import ExperiencePacket, to_frontmatter
+
+
+SCHEMA_VERSION = "compass.flywheel.event.v1"
+EVENT_KIND_EPISODE = "episode"
+PAYLOAD_SCHEMA = "compass.experience_packet.v0"
+
+_HASH_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+_UTC_RFC3339_PATTERN = re.compile(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z"
+)
+_PAYLOAD_KEYS = frozenset(field.name for field in fields(ExperiencePacket))
+
+
+class FlywheelEventError(ValueError):
+    """A fail-closed envelope validation error with a stable reason code."""
+
+    def __init__(self, reason_code: str, message: str | None = None) -> None:
+        self.reason_code = reason_code
+        super().__init__(message or reason_code)
+
+
+@dataclass(frozen=True)
+class FlywheelEvent:
+    """One normalized and immutable episode event."""
+
+    schema_version: str
+    event_kind: str
+    source_event_id: str
+    episode_id: str
+    parent_event_id: str | None
+    agent_id: int
+    occurred_at: str
+    payload_schema: str
+    payload: Mapping[str, Any]
+    payload_hash: str
+
+    def __post_init__(self) -> None:
+        _validate_constants(self)
+        _validate_id(self.source_event_id, "source_event_id")
+        _validate_id(self.episode_id, "episode_id")
+        if self.parent_event_id is not None:
+            _validate_id(self.parent_event_id, "parent_event_id")
+        _validate_agent_id(self.agent_id)
+        _validate_occurred_at(self.occurred_at)
+        _validate_payload_hash(self.payload_hash)
+
+        normalized_payload = _normalize_payload(self.payload)
+        if normalized_payload.get("episode_id") != self.episode_id:
+            raise FlywheelEventError(
+                "episode_id_mismatch",
+                "payload episode_id must be present and match the envelope episode_id",
+            )
+
+        expected_hash = _hash_bytes(_canonical_json_bytes(normalized_payload, "invalid_payload"))
+        if self.payload_hash != expected_hash:
+            raise FlywheelEventError(
+                "payload_hash_mismatch",
+                "payload_hash does not match the canonical normalized payload",
+            )
+
+        object.__setattr__(self, "payload", _freeze_json(normalized_payload))
+
+    @property
+    def event_hash(self) -> str:
+        """Return the SHA-256 hash of the canonical normalized envelope."""
+
+        return _hash_bytes(canonical_event_bytes(self))
+
+    def to_mapping(self) -> dict[str, Any]:
+        """Return a detached, JSON-ready envelope mapping."""
+
+        return to_mapping(self)
+
+
+_ENVELOPE_KEYS = tuple(field.name for field in fields(FlywheelEvent))
+_ENVELOPE_KEY_SET = frozenset(_ENVELOPE_KEYS)
+
+
+def canonical_payload_bytes(payload: Mapping[str, Any]) -> bytes:
+    """Serialize a strict, normalized ExperiencePacket payload canonically."""
+
+    normalized = _normalize_payload(payload)
+    return _canonical_json_bytes(normalized, "invalid_payload")
+
+
+def hash_payload(payload: Mapping[str, Any]) -> str:
+    """Hash a strict ExperiencePacket payload in canonical normalized form."""
+
+    return _hash_bytes(canonical_payload_bytes(payload))
+
+
+def canonical_event_bytes(event: FlywheelEvent | Mapping[str, Any]) -> bytes:
+    """Serialize an event or raw envelope in canonical normalized form."""
+
+    normalized_event = event if isinstance(event, FlywheelEvent) else event_from_mapping(event)
+    return _canonical_json_bytes(to_mapping(normalized_event), "invalid_schema")
+
+
+def event_from_mapping(raw_event: Mapping[str, Any]) -> FlywheelEvent:
+    """Validate and detach an exact v1 episode envelope mapping."""
+
+    if not isinstance(raw_event, Mapping):
+        raise FlywheelEventError("invalid_schema", "event must be a mapping")
+
+    try:
+        supplied_keys = frozenset(raw_event)
+    except (TypeError, ValueError) as exc:
+        raise FlywheelEventError("invalid_schema", "event keys are invalid") from exc
+
+    if supplied_keys != _ENVELOPE_KEY_SET:
+        missing = sorted(_ENVELOPE_KEY_SET - supplied_keys)
+        unknown = sorted((supplied_keys - _ENVELOPE_KEY_SET), key=repr)
+        details = []
+        if missing:
+            details.append(f"missing keys: {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown keys: {', '.join(map(str, unknown))}")
+        raise FlywheelEventError("invalid_schema", "; ".join(details))
+
+    try:
+        values = {key: raw_event[key] for key in _ENVELOPE_KEYS}
+    except (KeyError, TypeError, ValueError) as exc:
+        raise FlywheelEventError("invalid_schema", "event mapping could not be read") from exc
+    return FlywheelEvent(**values)
+
+
+def to_mapping(event: FlywheelEvent) -> dict[str, Any]:
+    """Return a detached mapping containing exactly the normalized envelope keys."""
+
+    if not isinstance(event, FlywheelEvent):
+        raise TypeError("event must be a FlywheelEvent")
+    return {
+        "schema_version": event.schema_version,
+        "event_kind": event.event_kind,
+        "source_event_id": event.source_event_id,
+        "episode_id": event.episode_id,
+        "parent_event_id": event.parent_event_id,
+        "agent_id": event.agent_id,
+        "occurred_at": event.occurred_at,
+        "payload_schema": event.payload_schema,
+        "payload": _thaw_json(event.payload),
+        "payload_hash": event.payload_hash,
+    }
+
+
+def _validate_constants(event: FlywheelEvent) -> None:
+    if event.schema_version != SCHEMA_VERSION:
+        raise FlywheelEventError("invalid_schema", "unsupported schema_version")
+    if event.event_kind != EVENT_KIND_EPISODE:
+        raise FlywheelEventError("invalid_schema", "unsupported event_kind")
+    if event.payload_schema != PAYLOAD_SCHEMA:
+        raise FlywheelEventError("invalid_schema", "unsupported payload_schema")
+
+
+def _validate_id(value: Any, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise FlywheelEventError("invalid_id", f"{field_name} must be a non-empty string")
+
+
+def _validate_agent_id(agent_id: Any) -> None:
+    if isinstance(agent_id, bool) or not isinstance(agent_id, int) or agent_id <= 0:
+        raise FlywheelEventError("invalid_agent_id", "agent_id must be a positive integer")
+
+
+def _validate_occurred_at(occurred_at: Any) -> None:
+    if not isinstance(occurred_at, str) or _UTC_RFC3339_PATTERN.fullmatch(occurred_at) is None:
+        raise FlywheelEventError(
+            "invalid_occurred_at",
+            "occurred_at must be an RFC3339 UTC timestamp ending in Z",
+        )
+    try:
+        datetime.fromisoformat(f"{occurred_at[:-1]}+00:00")
+    except ValueError as exc:
+        raise FlywheelEventError(
+            "invalid_occurred_at",
+            "occurred_at must be a valid RFC3339 UTC timestamp",
+        ) from exc
+
+
+def _validate_payload_hash(payload_hash: Any) -> None:
+    if not isinstance(payload_hash, str) or _HASH_PATTERN.fullmatch(payload_hash) is None:
+        raise FlywheelEventError(
+            "invalid_payload_hash",
+            "payload_hash must be sha256 followed by 64 lowercase hexadecimal characters",
+        )
+
+
+def _normalize_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise FlywheelEventError("invalid_payload", "payload must be a mapping")
+
+    try:
+        supplied_keys = frozenset(payload)
+    except (TypeError, ValueError) as exc:
+        raise FlywheelEventError("invalid_payload", "payload keys are invalid") from exc
+
+    unknown_keys = supplied_keys - _PAYLOAD_KEYS
+    if unknown_keys:
+        names = ", ".join(map(str, sorted(unknown_keys, key=repr)))
+        raise FlywheelEventError("invalid_schema", f"unknown payload keys: {names}")
+
+    try:
+        copied_payload = copy.deepcopy(dict(payload))
+        packet = ExperiencePacket(**copied_payload)
+        normalized = to_frontmatter(packet)
+    except (TypeError, ValueError) as exc:
+        raise FlywheelEventError("invalid_payload", "payload is not a valid ExperiencePacket") from exc
+
+    encoded = _canonical_json_bytes(normalized, "invalid_payload")
+    return json.loads(encoded)
+
+
+def _canonical_json_bytes(value: Any, reason_code: str) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise FlywheelEventError(reason_code, "value is not canonical JSON") from exc
+
+
+def _hash_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+__all__ = [
+    "EVENT_KIND_EPISODE",
+    "PAYLOAD_SCHEMA",
+    "SCHEMA_VERSION",
+    "FlywheelEvent",
+    "FlywheelEventError",
+    "canonical_event_bytes",
+    "canonical_payload_bytes",
+    "event_from_mapping",
+    "hash_payload",
+    "to_mapping",
+]

--- a/gep/flywheel_log.py
+++ b/gep/flywheel_log.py
@@ -261,6 +261,22 @@ class FlywheelEventLog:
                 SELECT RAISE(ABORT, 'flywheel_events rows are immutable');
             END;
             """,
+
+            """
+            CREATE TRIGGER IF NOT EXISTS flywheel_quarantine_immutable_update
+            BEFORE UPDATE ON flywheel_quarantine
+            BEGIN
+                SELECT RAISE(ABORT, 'flywheel_quarantine rows are immutable');
+            END;
+            """,
+
+            """
+            CREATE TRIGGER IF NOT EXISTS flywheel_quarantine_immutable_delete
+            BEFORE DELETE ON flywheel_quarantine
+            BEGIN
+                SELECT RAISE(ABORT, 'flywheel_quarantine rows are immutable');
+            END;
+            """,
         )
         for statement in statements:
             self._connection.execute(statement)

--- a/gep/flywheel_log.py
+++ b/gep/flywheel_log.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Literal, TypeVar
 
 from gep.flywheel_event import (
     FlywheelEvent,
@@ -34,6 +34,16 @@ class AppendReceipt:
     episode_id: str | None
     event_hash: str | None
     reason_code: str | None
+
+
+@dataclass(frozen=True)
+class EpisodeState:
+    """Derived state for one admitted episode event."""
+
+    episode_id: str
+    state: Literal["awaiting_verdict"]
+    source_event_id: str
+    event_hash: str
 
 
 class FlywheelEventLog:
@@ -266,6 +276,34 @@ class FlywheelEventLog:
             raise
 
 
+class CompassS4AgentHarness:
+    """Thin adapter from a structured runtime event to the durable log."""
+
+    def __init__(self, event_log: FlywheelEventLog) -> None:
+        self._event_log = event_log
+
+    def record(self, raw_event: Mapping[str, Any]) -> AppendReceipt:
+        """Delegate one structured event to the configured append-only log."""
+
+        return self._event_log.append(raw_event)
+
+
+def reduce_episode_states(events: Iterable[FlywheelEvent]) -> dict[str, EpisodeState]:
+    """Derive deterministic awaiting-verdict states without mutating events."""
+
+    states: dict[str, EpisodeState] = {}
+    for event in events:
+        if event.episode_id in states:
+            raise ValueError(f"duplicate episode_id: {event.episode_id}")
+        states[event.episode_id] = EpisodeState(
+            episode_id=event.episode_id,
+            state="awaiting_verdict",
+            source_event_id=event.source_event_id,
+            event_hash=event.event_hash,
+        )
+    return dict(sorted(states.items()))
+
+
 def _validate_registered_agent_ids(registered_agent_ids: Iterable[int]) -> frozenset[int]:
     try:
         ids = tuple(registered_agent_ids)
@@ -352,4 +390,10 @@ def _timestamp() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
-__all__ = ["AppendReceipt", "FlywheelEventLog"]
+__all__ = [
+    "AppendReceipt",
+    "CompassS4AgentHarness",
+    "EpisodeState",
+    "FlywheelEventLog",
+    "reduce_episode_states",
+]

--- a/gep/flywheel_log.py
+++ b/gep/flywheel_log.py
@@ -1,0 +1,327 @@
+"""SQLite persistence for validated Compass flywheel events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from os import PathLike
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+from gep.flywheel_event import (
+    FlywheelEvent,
+    FlywheelEventError,
+    canonical_event_bytes,
+    event_from_mapping,
+)
+
+
+_SAFE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True)
+class AppendReceipt:
+    """The durable outcome of one append attempt."""
+
+    status: str
+    source_event_id: str | None
+    episode_id: str | None
+    event_hash: str | None
+    reason_code: str | None
+
+
+class FlywheelEventLog:
+    """Persist validated flywheel events with fail-closed quarantine handling."""
+
+    def __init__(
+        self,
+        path: str | PathLike[str],
+        registered_agent_ids: Iterable[int],
+    ) -> None:
+        self._registered_agent_ids = _validate_registered_agent_ids(registered_agent_ids)
+        self._connection = sqlite3.connect(Path(path))
+        self._connection.row_factory = sqlite3.Row
+        try:
+            self._connection.execute("PRAGMA journal_mode = DELETE")
+            self._run_transaction(self._create_schema)
+        except Exception:
+            self._connection.close()
+            raise
+
+    def append(self, mapping: Mapping[str, Any]) -> AppendReceipt:
+        """Append one event, or durably record its safe quarantine outcome."""
+
+        try:
+            event = event_from_mapping(mapping)
+        except FlywheelEventError as error:
+            source_event_id, episode_id = _safe_ids(mapping)
+            fingerprint = _fingerprint(mapping)
+            receipt = AppendReceipt(
+                status="quarantined",
+                source_event_id=source_event_id,
+                episode_id=episode_id,
+                event_hash=None,
+                reason_code=error.reason_code,
+            )
+            self._run_transaction(
+                lambda: self._insert_quarantine(
+                    receipt,
+                    fingerprint,
+                )
+            )
+            return receipt
+
+        event_bytes = canonical_event_bytes(event)
+        if event.agent_id not in self._registered_agent_ids:
+            receipt = self._quarantine_event(event, "unregistered_agent")
+            self._run_transaction(lambda: self._insert_quarantine(receipt, event.event_hash))
+            return receipt
+
+        receipt = self._run_transaction(lambda: self._append_valid_event(event, event_bytes))
+        return receipt
+
+    def get(self, source_event_id: str) -> FlywheelEvent | None:
+        """Return the accepted event for a source ID, if one exists."""
+
+        row = self._connection.execute(
+            "SELECT envelope_json FROM flywheel_events WHERE source_event_id = ?",
+            (source_event_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return event_from_mapping(json.loads(row[0]))
+
+    def list_events(self) -> tuple[FlywheelEvent, ...]:
+        """Return accepted events in insertion order."""
+
+        rows = self._connection.execute(
+            "SELECT envelope_json FROM flywheel_events ORDER BY rowid"
+        ).fetchall()
+        return tuple(event_from_mapping(json.loads(row[0])) for row in rows)
+
+    def count_events(self) -> int:
+        """Return the number of accepted events."""
+
+        row = self._connection.execute("SELECT COUNT(*) FROM flywheel_events").fetchone()
+        return int(row[0])
+
+    def list_quarantine(self) -> tuple[dict[str, Any], ...]:
+        """Return safe quarantine metadata without raw event content."""
+
+        return tuple(
+            dict(row)
+            for row in self._connection.execute(
+                """
+                SELECT source_event_id, episode_id, reason_code,
+                       fingerprint, quarantined_at
+                FROM flywheel_quarantine
+                ORDER BY rowid
+                """
+            ).fetchall()
+        )
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+
+        self._connection.close()
+
+    def _append_valid_event(
+        self,
+        event: FlywheelEvent,
+        event_bytes: bytes,
+    ) -> AppendReceipt:
+        source_row = self._connection.execute(
+            "SELECT event_hash, envelope_json FROM flywheel_events WHERE source_event_id = ?",
+            (event.source_event_id,),
+        ).fetchone()
+        if source_row is not None:
+            if source_row[0] == event.event_hash and bytes(source_row[1]) == event_bytes:
+                return AppendReceipt(
+                    status="duplicate",
+                    source_event_id=event.source_event_id,
+                    episode_id=event.episode_id,
+                    event_hash=event.event_hash,
+                    reason_code=None,
+                )
+            receipt = self._quarantine_event(event, "source_event_conflict")
+            self._insert_quarantine(receipt, event.event_hash)
+            return receipt
+
+        episode_row = self._connection.execute(
+            "SELECT source_event_id FROM flywheel_events WHERE episode_id = ?",
+            (event.episode_id,),
+        ).fetchone()
+        if episode_row is not None:
+            receipt = self._quarantine_event(event, "episode_id_conflict")
+            self._insert_quarantine(receipt, event.event_hash)
+            return receipt
+
+        self._connection.execute(
+            """
+            INSERT INTO flywheel_events
+                (source_event_id, episode_id, event_hash, envelope_json, accepted_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                event.source_event_id,
+                event.episode_id,
+                event.event_hash,
+                sqlite3.Binary(event_bytes),
+                _timestamp(),
+            ),
+        )
+        return AppendReceipt(
+            status="accepted",
+            source_event_id=event.source_event_id,
+            episode_id=event.episode_id,
+            event_hash=event.event_hash,
+            reason_code=None,
+        )
+
+    def _quarantine_event(self, event: FlywheelEvent, reason_code: str) -> AppendReceipt:
+        return AppendReceipt(
+            status="quarantined" if reason_code == "unregistered_agent" else "conflict",
+            source_event_id=event.source_event_id,
+            episode_id=event.episode_id,
+            event_hash=event.event_hash,
+            reason_code=reason_code,
+        )
+
+    def _insert_quarantine(self, receipt: AppendReceipt, fingerprint: str) -> None:
+        self._connection.execute(
+            """
+            INSERT OR IGNORE INTO flywheel_quarantine
+                (source_event_id, episode_id, reason_code, fingerprint, quarantined_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                receipt.source_event_id,
+                receipt.episode_id,
+                receipt.reason_code,
+                fingerprint,
+                _timestamp(),
+            ),
+        )
+
+    def _create_schema(self) -> None:
+        statements = (
+            """
+            CREATE TABLE IF NOT EXISTS flywheel_events (
+                source_event_id TEXT NOT NULL UNIQUE,
+                episode_id TEXT NOT NULL UNIQUE,
+                event_hash TEXT NOT NULL,
+                envelope_json BLOB NOT NULL,
+                accepted_at TEXT NOT NULL
+            )
+            """,
+
+            """
+            CREATE TABLE IF NOT EXISTS flywheel_quarantine (
+                source_event_id TEXT,
+                episode_id TEXT,
+                reason_code TEXT NOT NULL,
+                fingerprint TEXT NOT NULL,
+                quarantined_at TEXT NOT NULL
+            )
+            """,
+
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS flywheel_quarantine_dedup
+                ON flywheel_quarantine (reason_code, fingerprint);
+            """,
+
+            """
+            CREATE TRIGGER IF NOT EXISTS flywheel_events_immutable_update
+            BEFORE UPDATE ON flywheel_events
+            BEGIN
+                SELECT RAISE(ABORT, 'flywheel_events rows are immutable');
+            END;
+            """,
+
+            """
+            CREATE TRIGGER IF NOT EXISTS flywheel_events_immutable_delete
+            BEFORE DELETE ON flywheel_events
+            BEGIN
+                SELECT RAISE(ABORT, 'flywheel_events rows are immutable');
+            END;
+            """,
+        )
+        for statement in statements:
+            self._connection.execute(statement)
+
+    def _run_transaction(self, operation: Callable[[], _T]) -> _T:
+        self._connection.execute("BEGIN IMMEDIATE")
+        try:
+            result = operation()
+            self._connection.commit()
+            return result
+        except Exception:
+            self._connection.rollback()
+            raise
+
+
+def _validate_registered_agent_ids(registered_agent_ids: Iterable[int]) -> frozenset[int]:
+    try:
+        ids = tuple(registered_agent_ids)
+    except TypeError as exc:
+        raise ValueError("registered_agent_ids must contain positive non-bool integers") from exc
+    if any(isinstance(agent_id, bool) or not isinstance(agent_id, int) or agent_id <= 0 for agent_id in ids):
+        raise ValueError("registered_agent_ids must contain positive non-bool integers")
+    return frozenset(ids)
+
+
+def _safe_ids(mapping: Any) -> tuple[str | None, str | None]:
+    if not isinstance(mapping, Mapping):
+        return None, None
+    return _safe_id(mapping.get("source_event_id")), _safe_id(mapping.get("episode_id"))
+
+
+def _safe_id(value: Any) -> str | None:
+    if not isinstance(value, str) or _SAFE_ID_PATTERN.fullmatch(value) is None:
+        return None
+    return value
+
+
+def _fingerprint(value: Any) -> str:
+    try:
+        normalized = _fingerprint_value(value)
+        encoded = json.dumps(
+            normalized,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, OverflowError):
+        encoded = repr(type(value)).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _fingerprint_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _fingerprint_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: repr(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_fingerprint_value(item) for item in value]
+    if isinstance(value, (str, int, bool)) or value is None:
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            return repr(value)
+        return value
+    return {"type": f"{type(value).__module__}.{type(value).__qualname__}"}
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+__all__ = ["AppendReceipt", "FlywheelEventLog"]

--- a/gep/flywheel_log.py
+++ b/gep/flywheel_log.py
@@ -295,42 +295,46 @@ def _fingerprint(value: Any) -> str:
 
 
 def _fingerprint_value(value: Any) -> Any:
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         entries = [
             [_fingerprint_value(key), _fingerprint_value(item)]
             for key, item in value.items()
         ]
         entries.sort(key=_fingerprint_json)
         return {"type": "mapping", "entries": entries}
-    if isinstance(value, list):
+    if type(value) is list:
         return {"type": "list", "items": [_fingerprint_value(item) for item in value]}
-    if isinstance(value, tuple):
+    if type(value) is tuple:
         return {"type": "tuple", "items": [_fingerprint_value(item) for item in value]}
     if value is None:
         return {"type": "none"}
-    if isinstance(value, bool):
+    if type(value) is bool:
         return {"type": "bool", "value": value}
-    if isinstance(value, int):
+    if type(value) is int:
         return {"type": "int", "value": str(value)}
-    if isinstance(value, str):
+    if type(value) is str:
         return {"type": "str", "value": value}
-    if isinstance(value, float):
-        return {"type": "float", "value": repr(value)}
-    if isinstance(value, bytes):
+    if type(value) is float:
+        return {"type": "float", "value": float.hex(value)}
+    if type(value) is bytes:
         return {"type": "bytes", "value": value.hex()}
-    if isinstance(value, bytearray):
+    if type(value) is bytearray:
         return {"type": "bytearray", "value": bytes(value).hex()}
-    if isinstance(value, set):
+    if type(value) is set:
         items = [_fingerprint_value(item) for item in value]
         items.sort(key=_fingerprint_json)
         return {"type": "set", "items": items}
-    if isinstance(value, frozenset):
+    if type(value) is frozenset:
         items = [_fingerprint_value(item) for item in value]
         items.sort(key=_fingerprint_json)
         return {"type": "frozenset", "items": items}
+    value_type = type(value)
+    module = type.__getattribute__(value_type, "__module__")
+    qualname = type.__getattribute__(value_type, "__qualname__")
     return {
-        "type": f"{type(value).__module__}.{type(value).__qualname__}",
-        "repr": repr(value),
+        "type": "opaque",
+        "class": f"{module}.{qualname}",
+        "value": "<opaque>",
     }
 
 

--- a/gep/flywheel_log.py
+++ b/gep/flywheel_log.py
@@ -289,35 +289,59 @@ def _safe_id(value: Any) -> str | None:
 
 
 def _fingerprint(value: Any) -> str:
-    try:
-        normalized = _fingerprint_value(value)
-        encoded = json.dumps(
-            normalized,
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
-            allow_nan=False,
-        ).encode("utf-8")
-    except (TypeError, ValueError, OverflowError):
-        encoded = repr(type(value)).encode("utf-8")
+    normalized = _fingerprint_value(value)
+    encoded = _fingerprint_json(normalized)
     return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
 
 
 def _fingerprint_value(value: Any) -> Any:
     if isinstance(value, Mapping):
-        return {
-            str(key): _fingerprint_value(item)
-            for key, item in sorted(value.items(), key=lambda pair: repr(pair[0]))
-        }
-    if isinstance(value, (list, tuple)):
-        return [_fingerprint_value(item) for item in value]
-    if isinstance(value, (str, int, bool)) or value is None:
-        return value
+        entries = [
+            [_fingerprint_value(key), _fingerprint_value(item)]
+            for key, item in value.items()
+        ]
+        entries.sort(key=_fingerprint_json)
+        return {"type": "mapping", "entries": entries}
+    if isinstance(value, list):
+        return {"type": "list", "items": [_fingerprint_value(item) for item in value]}
+    if isinstance(value, tuple):
+        return {"type": "tuple", "items": [_fingerprint_value(item) for item in value]}
+    if value is None:
+        return {"type": "none"}
+    if isinstance(value, bool):
+        return {"type": "bool", "value": value}
+    if isinstance(value, int):
+        return {"type": "int", "value": str(value)}
+    if isinstance(value, str):
+        return {"type": "str", "value": value}
     if isinstance(value, float):
-        if value != value or value in (float("inf"), float("-inf")):
-            return repr(value)
-        return value
-    return {"type": f"{type(value).__module__}.{type(value).__qualname__}"}
+        return {"type": "float", "value": repr(value)}
+    if isinstance(value, bytes):
+        return {"type": "bytes", "value": value.hex()}
+    if isinstance(value, bytearray):
+        return {"type": "bytearray", "value": bytes(value).hex()}
+    if isinstance(value, set):
+        items = [_fingerprint_value(item) for item in value]
+        items.sort(key=_fingerprint_json)
+        return {"type": "set", "items": items}
+    if isinstance(value, frozenset):
+        items = [_fingerprint_value(item) for item in value]
+        items.sort(key=_fingerprint_json)
+        return {"type": "frozenset", "items": items}
+    return {
+        "type": f"{type(value).__module__}.{type(value).__qualname__}",
+        "repr": repr(value),
+    }
+
+
+def _fingerprint_json(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
 
 
 def _timestamp() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,8 @@ compass-session-writer = "nautilus_compass.session_writer:main"
 # v1.6.2 was broken — only top-level was packaged, so `nautilus_compass.sdk`
 # and `nautilus_compass.middleware` imports failed at install time.
 # Explicit list (not `find`) avoids setuptools treating tests/, scripts/, etc as packages.
-packages = ["nautilus_compass", "nautilus_compass.sdk", "nautilus_compass.middleware", "nautilus_compass.storage", "nautilus_compass.proof", "nautilus_compass.drift", "nautilus_compass.recall_pkg", "nautilus_compass.skills_pkg", "nautilus_compass.judges"]
-package-dir = {"nautilus_compass" = ".", "nautilus_compass.sdk" = "sdk", "nautilus_compass.middleware" = "middleware", "nautilus_compass.storage" = "storage", "nautilus_compass.proof" = "proof", "nautilus_compass.drift" = "drift", "nautilus_compass.recall_pkg" = "recall_pkg", "nautilus_compass.skills_pkg" = "skills_pkg", "nautilus_compass.judges" = "judges"}
+packages = ["nautilus_compass", "nautilus_compass.sdk", "nautilus_compass.middleware", "nautilus_compass.storage", "nautilus_compass.proof", "nautilus_compass.drift", "nautilus_compass.recall_pkg", "nautilus_compass.skills_pkg", "nautilus_compass.judges", "gep"]
+package-dir = {"nautilus_compass" = ".", "nautilus_compass.sdk" = "sdk", "nautilus_compass.middleware" = "middleware", "nautilus_compass.storage" = "storage", "nautilus_compass.proof" = "proof", "nautilus_compass.drift" = "drift", "nautilus_compass.recall_pkg" = "recall_pkg", "nautilus_compass.skills_pkg" = "skills_pkg", "nautilus_compass.judges" = "judges", "gep" = "gep"}
 
 [tool.setuptools.package-data]
 "nautilus_compass" = ["anchors*.json", "*.sh"]

--- a/tests/gep/test_experience_packet.py
+++ b/tests/gep/test_experience_packet.py
@@ -28,6 +28,47 @@ def test_all_fields_are_optional():
     assert all(getattr(packet, name) is None for name in EXPECTED_FIELDS)
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("episode_id", 1),
+        ("parent_episode_id", 1),
+        ("task", 123),
+        ("action_kind", ()),
+        ("outcome", False),
+        ("failure_mode", {}),
+        ("route_key", []),
+        ("policy_hint", 1.5),
+        ("capsule_candidate", "yes"),
+        ("capsule_candidate", 1),
+        ("reward_delta", True),
+        ("reward_delta", "1.0"),
+        ("impact", False),
+        ("impact", "high"),
+    ],
+)
+def test_scalar_fields_reject_wrong_runtime_types(field_name, value):
+    with pytest.raises(TypeError, match=rf"{field_name} must"):
+        ExperiencePacket(**{field_name: value})
+
+
+@pytest.mark.parametrize("field_name", ["reward_delta", "impact"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_numeric_fields_reject_non_finite_values(field_name, value):
+    with pytest.raises(ValueError, match=rf"{field_name} must be finite"):
+        ExperiencePacket(**{field_name: value})
+
+
+@pytest.mark.parametrize("field_name", ["reward_delta", "impact"])
+@pytest.mark.parametrize("value", [2, -0.5])
+def test_numeric_fields_normalize_ints_and_floats(field_name, value):
+    packet = ExperiencePacket(**{field_name: value})
+    normalized = getattr(packet, field_name)
+
+    assert normalized == float(value)
+    assert type(normalized) is float
+
+
 def test_packet_is_immutable():
     packet = ExperiencePacket(episode_id="episode-1")
 
@@ -121,6 +162,8 @@ def test_from_args_accepts_mapping_and_explicit_overrides():
         outcome="succeeded",
         impact=2,
     )
+    assert packet.impact == 2.0
+    assert type(packet.impact) is float
 
 
 def test_from_args_treats_a_string_tool_as_one_tool():

--- a/tests/gep/test_flywheel_event.py
+++ b/tests/gep/test_flywheel_event.py
@@ -1,0 +1,330 @@
+import hashlib
+import json
+from dataclasses import FrozenInstanceError, fields
+
+import pytest
+
+from gep.flywheel_event import (
+    EVENT_KIND_EPISODE,
+    PAYLOAD_SCHEMA,
+    SCHEMA_VERSION,
+    FlywheelEvent,
+    FlywheelEventError,
+    canonical_event_bytes,
+    canonical_payload_bytes,
+    event_from_mapping,
+    hash_payload,
+    to_mapping,
+)
+
+
+ENVELOPE_KEYS = (
+    "schema_version",
+    "event_kind",
+    "source_event_id",
+    "episode_id",
+    "parent_event_id",
+    "agent_id",
+    "occurred_at",
+    "payload_schema",
+    "payload",
+    "payload_hash",
+)
+
+
+def valid_mapping(**overrides):
+    payload = overrides.pop(
+        "payload",
+        {"episode_id": "episode-1", "task": "verify a fix"},
+    )
+    if "payload_hash" in overrides:
+        payload_hash = overrides.pop("payload_hash")
+    else:
+        payload_hash = hash_payload(payload)
+    event = {
+        "schema_version": SCHEMA_VERSION,
+        "event_kind": EVENT_KIND_EPISODE,
+        "source_event_id": "source-1",
+        "episode_id": "episode-1",
+        "parent_event_id": None,
+        "agent_id": 7,
+        "occurred_at": "2026-07-31T12:00:00Z",
+        "payload_schema": PAYLOAD_SCHEMA,
+        "payload": payload,
+        "payload_hash": payload_hash,
+    }
+    event.update(overrides)
+    return event
+
+
+def assert_rejected(mapping, reason_code=None):
+    with pytest.raises(FlywheelEventError) as exc_info:
+        event_from_mapping(mapping)
+
+    assert exc_info.value.reason_code
+    if reason_code is not None:
+        assert exc_info.value.reason_code == reason_code
+
+
+def test_constants_and_envelope_fields_are_exact():
+    event = event_from_mapping(valid_mapping())
+
+    assert SCHEMA_VERSION == "compass.flywheel.event.v1"
+    assert EVENT_KIND_EPISODE == "episode"
+    assert PAYLOAD_SCHEMA == "compass.experience_packet.v0"
+    assert tuple(field.name for field in fields(FlywheelEvent)) == ENVELOPE_KEYS
+    assert tuple(to_mapping(event)) == ENVELOPE_KEYS
+
+
+def test_valid_episode_round_trips_through_canonical_normalized_json():
+    raw = valid_mapping(
+        parent_event_id="source-0",
+        payload={
+            "episode_id": "episode-1",
+            "task": "验证修复",
+            "tool_chain": ["inspect", "验证"],
+            "capsule_candidate": False,
+            "failure_mode": None,
+        },
+    )
+
+    event = event_from_mapping(raw)
+    normalized = to_mapping(event)
+    expected_payload = {
+        "capsule_candidate": False,
+        "episode_id": "episode-1",
+        "task": "验证修复",
+        "tool_chain": ["inspect", "验证"],
+    }
+
+    assert normalized["payload"] == expected_payload
+    assert normalized["payload_hash"] == hash_payload(expected_payload)
+    assert event.to_mapping() == normalized
+    assert canonical_event_bytes(event) == json.dumps(
+        normalized,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    assert canonical_event_bytes(raw) == canonical_event_bytes(event)
+
+
+def test_payload_bytes_and_hash_use_canonical_utf8_json():
+    payload = {
+        "task": "验证修复",
+        "episode_id": "episode-1",
+        "tool_chain": ("search", "验证"),
+    }
+    expected = (
+        '{"episode_id":"episode-1","task":"验证修复",'
+        '"tool_chain":["search","验证"]}'
+    ).encode("utf-8")
+
+    assert canonical_payload_bytes(payload) == expected
+    assert hash_payload(payload) == f"sha256:{hashlib.sha256(expected).hexdigest()}"
+
+
+def test_event_hash_is_deterministic_and_derived_from_normalized_envelope():
+    first = event_from_mapping(valid_mapping())
+    second = event_from_mapping(valid_mapping())
+    expected = f"sha256:{hashlib.sha256(canonical_event_bytes(first)).hexdigest()}"
+
+    assert first.event_hash == expected
+    assert second.event_hash == expected
+    assert "event_hash" not in to_mapping(first)
+
+    changed = event_from_mapping(valid_mapping(source_event_id="source-2"))
+    assert changed.event_hash != first.event_hash
+
+
+def test_event_hash_is_not_accepted_as_input():
+    raw = valid_mapping()
+    raw["event_hash"] = "sha256:" + "0" * 64
+
+    assert_rejected(raw, "invalid_schema")
+
+
+@pytest.mark.parametrize("key", ENVELOPE_KEYS)
+def test_missing_envelope_key_fails_closed(key):
+    raw = valid_mapping()
+    raw.pop(key)
+
+    assert_rejected(raw, "invalid_schema")
+
+
+def test_unknown_envelope_key_fails_closed():
+    raw = valid_mapping()
+    raw["future_field"] = "must not disappear"
+
+    assert_rejected(raw, "invalid_schema")
+
+
+def test_unknown_payload_key_fails_closed():
+    raw = valid_mapping(
+        payload={
+            "episode_id": "episode-1",
+            "task": "verify a fix",
+            "future_field": "must not disappear",
+        },
+        payload_hash="sha256:" + "0" * 64,
+    )
+
+    assert_rejected(raw, "invalid_schema")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", "compass.flywheel.event.v0"),
+        ("event_kind", "verdict"),
+        ("payload_schema", "compass.experience_packet.v1"),
+    ],
+)
+def test_wrong_constants_fail_closed(field, value):
+    assert_rejected(valid_mapping(**{field: value}), "invalid_schema")
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_event_id", ""),
+        ("source_event_id", "   "),
+        ("source_event_id", None),
+        ("episode_id", ""),
+        ("episode_id", "   "),
+        ("episode_id", 9),
+        ("parent_event_id", ""),
+        ("parent_event_id", "   "),
+        ("parent_event_id", 9),
+    ],
+)
+def test_invalid_ids_are_rejected(field, value):
+    assert_rejected(valid_mapping(**{field: value}), "invalid_id")
+
+
+@pytest.mark.parametrize("agent_id", [True, False, 0, -1, 1.5, "7", None])
+def test_agent_id_must_be_a_positive_non_bool_integer(agent_id):
+    assert_rejected(valid_mapping(agent_id=agent_id), "invalid_agent_id")
+
+
+@pytest.mark.parametrize(
+    "occurred_at",
+    [
+        "2026-07-31T12:00:00+00:00",
+        "2026-07-31T06:00:00-06:00",
+        "2026-07-31 12:00:00Z",
+        "2026-07-31T12:00:00z",
+        "2026-07-31T12:00Z",
+        "2026-02-29T12:00:00Z",
+        "",
+        None,
+    ],
+)
+def test_occurred_at_requires_strict_utc_rfc3339_ending_z(occurred_at):
+    assert_rejected(valid_mapping(occurred_at=occurred_at), "invalid_occurred_at")
+
+
+def test_fractional_seconds_are_valid_utc_rfc3339():
+    event = event_from_mapping(valid_mapping(occurred_at="2026-07-31T12:00:00.123456Z"))
+
+    assert event.occurred_at == "2026-07-31T12:00:00.123456Z"
+
+
+@pytest.mark.parametrize(
+    "payload_hash",
+    [
+        "",
+        "0" * 64,
+        "sha256:" + "0" * 63,
+        "sha256:" + "A" * 64,
+        "SHA256:" + "0" * 64,
+        None,
+    ],
+)
+def test_payload_hash_format_is_strict(payload_hash):
+    assert_rejected(valid_mapping(payload_hash=payload_hash), "invalid_payload_hash")
+
+
+def test_payload_hash_must_match_canonical_normalized_payload():
+    assert_rejected(
+        valid_mapping(payload_hash="sha256:" + "0" * 64),
+        "payload_hash_mismatch",
+    )
+
+
+def test_payload_must_be_a_mapping():
+    assert_rejected(
+        valid_mapping(payload=[("episode_id", "episode-1")], payload_hash="sha256:" + "0" * 64),
+        "invalid_payload",
+    )
+
+
+def test_payload_must_include_episode_id():
+    payload = {"task": "verify a fix"}
+
+    assert_rejected(valid_mapping(payload=payload), "episode_id_mismatch")
+
+
+def test_payload_episode_id_must_match_envelope():
+    payload = {"episode_id": "episode-2", "task": "verify a fix"}
+
+    assert_rejected(valid_mapping(payload=payload), "episode_id_mismatch")
+
+
+def test_nan_is_rejected_by_payload_and_event_canonicalization():
+    payload = {"episode_id": "episode-1", "reward_delta": float("nan")}
+
+    with pytest.raises(FlywheelEventError) as exc_info:
+        canonical_payload_bytes(payload)
+    assert exc_info.value.reason_code == "invalid_payload"
+
+    assert_rejected(
+        valid_mapping(payload=payload, payload_hash="sha256:" + "0" * 64),
+        "invalid_payload",
+    )
+
+
+def test_event_and_payload_are_immutable_deep_copies():
+    tools = ["inspect", "verify"]
+    raw = valid_mapping(
+        payload={
+            "episode_id": "episode-1",
+            "task": "verify a fix",
+            "tool_chain": tools,
+        }
+    )
+    event = event_from_mapping(raw)
+
+    tools.append("caller-mutation")
+    raw["source_event_id"] = "caller-mutated-source"
+    raw["payload"]["task"] = "caller-mutated-task"
+
+    assert event.source_event_id == "source-1"
+    assert event.payload["task"] == "verify a fix"
+    assert event.payload["tool_chain"] == ("inspect", "verify")
+
+    with pytest.raises(FrozenInstanceError):
+        event.source_event_id = "cannot-mutate"
+    with pytest.raises(TypeError):
+        event.payload["task"] = "cannot-mutate"
+
+    exported = to_mapping(event)
+    exported["payload"]["tool_chain"].append("export-mutation")
+    assert event.payload["tool_chain"] == ("inspect", "verify")
+
+
+def test_direct_construction_applies_the_same_validation_and_copying():
+    raw = valid_mapping()
+    event = FlywheelEvent(**raw)
+    raw["payload"]["task"] = "caller-mutated-task"
+
+    assert event == event_from_mapping(valid_mapping())
+    assert event.payload["task"] == "verify a fix"
+
+
+def test_event_from_mapping_rejects_non_mapping_input():
+    with pytest.raises(FlywheelEventError) as exc_info:
+        event_from_mapping([])
+
+    assert exc_info.value.reason_code == "invalid_schema"

--- a/tests/gep/test_flywheel_event.py
+++ b/tests/gep/test_flywheel_event.py
@@ -260,6 +260,25 @@ def test_payload_must_be_a_mapping():
     )
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("task", 123),
+        ("capsule_candidate", "yes"),
+        ("reward_delta", True),
+        ("impact", "high"),
+        ("route_key", []),
+    ],
+)
+def test_invalid_experience_packet_field_types_map_to_invalid_payload(field_name, value):
+    payload = {"episode_id": "episode-1", field_name: value}
+
+    assert_rejected(
+        valid_mapping(payload=payload, payload_hash="sha256:" + "0" * 64),
+        "invalid_payload",
+    )
+
+
 def test_payload_must_include_episode_id():
     payload = {"task": "verify a fix"}
 

--- a/tests/gep/test_flywheel_log.py
+++ b/tests/gep/test_flywheel_log.py
@@ -1,9 +1,12 @@
+import ast
 import re
 import sqlite3
 from dataclasses import FrozenInstanceError, fields
+from pathlib import Path
 
 import pytest
 
+import gep.flywheel_log as flywheel_log_module
 from gep.flywheel_event import canonical_event_bytes, event_from_mapping, hash_payload
 from gep.flywheel_log import AppendReceipt, FlywheelEventLog
 
@@ -416,3 +419,126 @@ def test_sqlite_write_failure_raises_and_rolls_back_instead_of_accepting(log_and
 
     assert event_log.count_events() == 0
     assert event_log.list_quarantine() == ()
+
+
+def test_harness_record_delegates_the_original_mapping_and_returns_frozen_receipt():
+    expected = AppendReceipt(
+        status="accepted",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash="sha256:" + "0" * 64,
+        reason_code=None,
+    )
+
+    class RecordingLog:
+        def __init__(self):
+            self.recorded = None
+
+        def append(self, raw_event):
+            self.recorded = raw_event
+            return expected
+
+    raw = valid_mapping()
+    event_log = RecordingLog()
+    harness = flywheel_log_module.CompassS4AgentHarness(event_log)
+
+    receipt = harness.record(raw)
+
+    assert event_log.recorded is raw
+    assert receipt is expected
+    with pytest.raises(FrozenInstanceError):
+        receipt.status = "duplicate"
+
+
+@pytest.fixture
+def one_shot_harness(tmp_path):
+    event_log = FlywheelEventLog(
+        tmp_path / "one-shot.sqlite3",
+        registered_agent_ids={7},
+    )
+    try:
+        yield flywheel_log_module.CompassS4AgentHarness(event_log), event_log
+    finally:
+        event_log.close()
+
+
+def test_one_shot_harness_records_and_reads_episode_without_chat_runtime_imports(
+    one_shot_harness,
+):
+    harness, event_log = one_shot_harness
+    raw = valid_mapping()
+    expected = event_from_mapping(raw)
+
+    receipt = harness.record(raw)
+
+    assert receipt.status == "accepted"
+    assert event_log.get("source-1") == expected
+
+    source = Path(flywheel_log_module.__file__).read_text(encoding="utf-8")
+    imported_roots = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported_roots.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_roots.add(node.module.split(".", 1)[0])
+    assert imported_roots.isdisjoint(
+        {"anthropic", "claude", "codex", "langchain", "langgraph", "openai"}
+    )
+
+
+def test_reducer_returns_frozen_awaiting_verdict_states_with_lineage():
+    first = event_from_mapping(valid_mapping())
+    second_raw = valid_mapping(
+        source_event_id="source-2",
+        episode_id="episode-2",
+        payload={"episode_id": "episode-2", "task": "verify another fix"},
+    )
+    second = event_from_mapping(second_raw)
+
+    states = flywheel_log_module.reduce_episode_states((second, first))
+
+    assert tuple(states) == ("episode-1", "episode-2")
+    assert states["episode-1"] == flywheel_log_module.EpisodeState(
+        episode_id="episode-1",
+        state="awaiting_verdict",
+        source_event_id="source-1",
+        event_hash=first.event_hash,
+    )
+    assert states["episode-2"].source_event_id == "source-2"
+    assert states["episode-2"].event_hash == second.event_hash
+    with pytest.raises(FrozenInstanceError):
+        states["episode-1"].state = "changed"
+
+
+def test_reducer_is_deterministic_and_does_not_modify_its_input():
+    first = event_from_mapping(valid_mapping())
+    second = event_from_mapping(
+        valid_mapping(
+            source_event_id="source-2",
+            episode_id="episode-2",
+            payload={"episode_id": "episode-2", "task": "second task"},
+        )
+    )
+    events = [second, first]
+    before = tuple(events)
+
+    first_result = flywheel_log_module.reduce_episode_states(events)
+    second_result = flywheel_log_module.reduce_episode_states(reversed(events))
+
+    assert first_result == second_result
+    assert tuple(first_result) == tuple(second_result) == ("episode-1", "episode-2")
+    assert tuple(events) == before
+
+
+def test_reducer_returns_empty_mapping_for_empty_input():
+    assert flywheel_log_module.reduce_episode_states(()) == {}
+
+
+def test_reducer_rejects_duplicate_episode_ids_without_silent_overwrite():
+    first = event_from_mapping(valid_mapping())
+    competing = event_from_mapping(valid_mapping(source_event_id="source-2"))
+
+    with pytest.raises(ValueError, match=r"duplicate episode_id: episode-1"):
+        flywheel_log_module.reduce_episode_states((first, competing))
+    with pytest.raises(ValueError, match=r"duplicate episode_id: episode-1"):
+        flywheel_log_module.reduce_episode_states((competing, first))

--- a/tests/gep/test_flywheel_log.py
+++ b/tests/gep/test_flywheel_log.py
@@ -1,0 +1,354 @@
+import re
+import sqlite3
+from dataclasses import FrozenInstanceError, fields
+
+import pytest
+
+from gep.flywheel_event import canonical_event_bytes, event_from_mapping, hash_payload
+from gep.flywheel_log import AppendReceipt, FlywheelEventLog
+
+
+def valid_mapping(**overrides):
+    payload = overrides.pop(
+        "payload",
+        {"episode_id": "episode-1", "task": "verify a fix"},
+    )
+    payload_hash = overrides.pop("payload_hash", hash_payload(payload))
+    event = {
+        "schema_version": "compass.flywheel.event.v1",
+        "event_kind": "episode",
+        "source_event_id": "source-1",
+        "episode_id": "episode-1",
+        "parent_event_id": None,
+        "agent_id": 7,
+        "occurred_at": "2026-07-31T12:00:00Z",
+        "payload_schema": "compass.experience_packet.v0",
+        "payload": payload,
+        "payload_hash": payload_hash,
+    }
+    event.update(overrides)
+    return event
+
+
+def table_columns(path, table):
+    with sqlite3.connect(path) as connection:
+        return tuple(row[1] for row in connection.execute(f"PRAGMA table_info({table})"))
+
+
+@pytest.fixture
+def log_and_path(tmp_path):
+    path = tmp_path / "flywheel.sqlite3"
+    event_log = FlywheelEventLog(path, registered_agent_ids={7})
+    yield event_log, path
+    event_log.close()
+
+
+def test_append_receipt_is_frozen_and_has_the_exact_public_fields():
+    receipt = AppendReceipt(
+        status="accepted",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash="sha256:" + "0" * 64,
+        reason_code=None,
+    )
+
+    assert tuple(field.name for field in fields(AppendReceipt)) == (
+        "status",
+        "source_event_id",
+        "episode_id",
+        "event_hash",
+        "reason_code",
+    )
+    with pytest.raises(FrozenInstanceError):
+        receipt.status = "duplicate"
+
+
+@pytest.mark.parametrize(
+    "registered_agent_ids",
+    [(True,), (False,), (0,), (-1,), (1.5,), ("7",), (7, True)],
+)
+def test_registered_agent_ids_must_be_positive_non_bool_integers(
+    tmp_path, registered_agent_ids
+):
+    path = tmp_path / "invalid-registry.sqlite3"
+
+    with pytest.raises(ValueError, match="positive non-bool integers"):
+        FlywheelEventLog(path, registered_agent_ids)
+
+    assert not path.exists()
+
+
+def test_first_valid_append_is_committed_and_readable(log_and_path):
+    event_log, path = log_and_path
+    raw = valid_mapping()
+    expected = event_from_mapping(raw)
+
+    receipt = event_log.append(raw)
+
+    assert receipt == AppendReceipt(
+        status="accepted",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash=expected.event_hash,
+        reason_code=None,
+    )
+    assert event_log.get("source-1") == expected
+    assert event_log.get("missing-source") is None
+    assert event_log.list_events() == (expected,)
+    assert event_log.count_events() == 1
+    assert event_log.list_quarantine() == ()
+
+    assert table_columns(path, "flywheel_events") == (
+        "source_event_id",
+        "episode_id",
+        "event_hash",
+        "envelope_json",
+        "accepted_at",
+    )
+    with sqlite3.connect(path) as connection:
+        row = connection.execute(
+            """
+            SELECT source_event_id, episode_id, event_hash,
+                   typeof(envelope_json), envelope_json, accepted_at
+            FROM flywheel_events
+            """
+        ).fetchone()
+        tables = {
+            item[0]
+            for item in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+            if not item[0].startswith("sqlite_")
+        }
+
+    assert row[:4] == ("source-1", "episode-1", expected.event_hash, "blob")
+    assert row[4] == canonical_event_bytes(expected)
+    assert row[5].endswith("Z")
+    assert tables == {"flywheel_events", "flywheel_quarantine"}
+
+
+def test_accepted_rows_are_immutable_at_the_database_boundary(log_and_path):
+    event_log, path = log_and_path
+    event_log.append(valid_mapping())
+
+    with sqlite3.connect(path) as connection:
+        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            connection.execute(
+                "UPDATE flywheel_events SET event_hash = ? WHERE source_event_id = ?",
+                ("sha256:" + "0" * 64, "source-1"),
+            )
+
+    assert event_log.get("source-1") == event_from_mapping(valid_mapping())
+
+
+def test_replaying_the_same_event_100_times_is_idempotent(log_and_path):
+    event_log, _ = log_and_path
+    raw = valid_mapping()
+
+    receipts = [event_log.append(raw) for _ in range(100)]
+
+    assert receipts[0].status == "accepted"
+    assert [receipt.status for receipt in receipts[1:]] == ["duplicate"] * 99
+    assert all(receipt.event_hash == receipts[0].event_hash for receipt in receipts)
+    assert all(receipt.reason_code is None for receipt in receipts)
+    assert event_log.count_events() == 1
+    assert event_log.list_quarantine() == ()
+
+
+def test_reopen_preserves_canonical_envelope_bytes_and_event_hash(tmp_path):
+    path = tmp_path / "restart.sqlite3"
+    raw = valid_mapping(
+        payload={
+            "episode_id": "episode-1",
+            "task": "验证重启恢复",
+            "tool_chain": ["inspect", "verify"],
+        }
+    )
+    expected = event_from_mapping(raw)
+    first_log = FlywheelEventLog(path, registered_agent_ids={7})
+    first_log.append(raw)
+    with sqlite3.connect(path) as connection:
+        before = connection.execute(
+            "SELECT envelope_json, event_hash FROM flywheel_events"
+        ).fetchone()
+    first_log.close()
+
+    reopened = FlywheelEventLog(path, registered_agent_ids={7})
+    try:
+        restored = reopened.get("source-1")
+        with sqlite3.connect(path) as connection:
+            after = connection.execute(
+                "SELECT envelope_json, event_hash FROM flywheel_events"
+            ).fetchone()
+
+        assert restored == expected
+        assert canonical_event_bytes(restored) == canonical_event_bytes(expected)
+        assert before == after == (canonical_event_bytes(expected), expected.event_hash)
+        assert reopened.list_events() == (expected,)
+        assert reopened.count_events() == 1
+    finally:
+        reopened.close()
+
+
+def test_same_source_with_changed_content_conflicts_without_overwrite(log_and_path):
+    event_log, path = log_and_path
+    original = valid_mapping()
+    changed = valid_mapping(
+        payload={"episode_id": "episode-1", "task": "changed content"}
+    )
+    original_event = event_from_mapping(original)
+    changed_event = event_from_mapping(changed)
+    event_log.append(original)
+
+    receipt = event_log.append(changed)
+
+    assert receipt == AppendReceipt(
+        status="conflict",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash=changed_event.event_hash,
+        reason_code="source_event_conflict",
+    )
+    assert event_log.count_events() == 1
+    assert event_log.get("source-1") == original_event
+    assert event_log.list_quarantine()[0]["reason_code"] == "source_event_conflict"
+    with sqlite3.connect(path) as connection:
+        stored = connection.execute(
+            "SELECT envelope_json, event_hash FROM flywheel_events"
+        ).fetchone()
+    assert stored == (canonical_event_bytes(original_event), original_event.event_hash)
+
+
+def test_same_episode_under_another_source_conflicts_and_is_quarantined(log_and_path):
+    event_log, _ = log_and_path
+    event_log.append(valid_mapping())
+    competing = valid_mapping(source_event_id="source-2")
+    competing_event = event_from_mapping(competing)
+
+    receipt = event_log.append(competing)
+
+    assert receipt == AppendReceipt(
+        status="conflict",
+        source_event_id="source-2",
+        episode_id="episode-1",
+        event_hash=competing_event.event_hash,
+        reason_code="episode_id_conflict",
+    )
+    assert event_log.count_events() == 1
+    assert event_log.get("source-2") is None
+    assert event_log.list_quarantine()[0]["reason_code"] == "episode_id_conflict"
+
+
+def test_unregistered_agent_is_quarantined_without_an_event_row(log_and_path):
+    event_log, _ = log_and_path
+    raw = valid_mapping(agent_id=8)
+    expected_hash = event_from_mapping(raw).event_hash
+
+    receipt = event_log.append(raw)
+
+    assert receipt == AppendReceipt(
+        status="quarantined",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash=expected_hash,
+        reason_code="unregistered_agent",
+    )
+    assert event_log.count_events() == 0
+    assert event_log.list_quarantine()[0]["reason_code"] == "unregistered_agent"
+
+
+def test_flywheel_event_errors_supply_quarantine_reason_codes(log_and_path):
+    event_log, _ = log_and_path
+    invalid_schema = valid_mapping()
+    invalid_schema["unknown_envelope_field"] = "reject-me"
+    bad_hash = valid_mapping(payload_hash="sha256:" + "0" * 64)
+
+    schema_receipt = event_log.append(invalid_schema)
+    hash_receipt = event_log.append(bad_hash)
+
+    assert schema_receipt == AppendReceipt(
+        status="quarantined",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash=None,
+        reason_code="invalid_schema",
+    )
+    assert hash_receipt == AppendReceipt(
+        status="quarantined",
+        source_event_id="source-1",
+        episode_id="episode-1",
+        event_hash=None,
+        reason_code="payload_hash_mismatch",
+    )
+    assert event_log.count_events() == 0
+    assert {row["reason_code"] for row in event_log.list_quarantine()} == {
+        "invalid_schema",
+        "payload_hash_mismatch",
+    }
+
+
+def test_quarantine_schema_and_rows_never_persist_raw_sensitive_input(tmp_path):
+    path = tmp_path / "safe-quarantine.sqlite3"
+    event_log = FlywheelEventLog(path, registered_agent_ids={7})
+    secret = "SENSITIVE-PASSWORD-DO-NOT-PERSIST"
+    url = "https://private.example.invalid/token"
+    raw = valid_mapping(
+        source_event_id=url,
+        payload={"episode_id": "episode-safe", "task": secret},
+        episode_id="episode-safe",
+    )
+    raw["unknown_input"] = {"password": secret, "url": url}
+
+    first = event_log.append(raw)
+    second = event_log.append(raw)
+    rows = event_log.list_quarantine()
+    event_log.close()
+
+    assert first.status == second.status == "quarantined"
+    assert first.reason_code == second.reason_code == "invalid_schema"
+    assert first.source_event_id is None
+    assert first.episode_id == "episode-safe"
+    assert len(rows) == 1
+    assert tuple(rows[0]) == (
+        "source_event_id",
+        "episode_id",
+        "reason_code",
+        "fingerprint",
+        "quarantined_at",
+    )
+    assert rows[0]["source_event_id"] is None
+    assert rows[0]["episode_id"] == "episode-safe"
+    assert rows[0]["reason_code"] == "invalid_schema"
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", rows[0]["fingerprint"])
+    assert rows[0]["quarantined_at"].endswith("Z")
+    assert table_columns(path, "flywheel_quarantine") == (
+        "source_event_id",
+        "episode_id",
+        "reason_code",
+        "fingerprint",
+        "quarantined_at",
+    )
+
+    database_bytes = path.read_bytes()
+    for forbidden in (secret, url, "unknown_input", "password", "task"):
+        assert forbidden.encode() not in database_bytes
+
+
+def test_sqlite_write_failure_raises_and_rolls_back_instead_of_accepting(log_and_path):
+    event_log, path = log_and_path
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TRIGGER force_event_write_failure
+            BEFORE INSERT ON flywheel_events
+            BEGIN
+                SELECT RAISE(ABORT, 'forced write failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="forced write failure"):
+        event_log.append(valid_mapping())
+
+    assert event_log.count_events() == 0
+    assert event_log.list_quarantine() == ()

--- a/tests/gep/test_flywheel_log.py
+++ b/tests/gep/test_flywheel_log.py
@@ -153,6 +153,26 @@ def test_accepted_rows_are_immutable_at_the_database_boundary(log_and_path):
     assert event_log.get("source-1") == event_from_mapping(valid_mapping())
 
 
+def test_quarantine_rows_are_immutable_at_the_database_boundary(log_and_path):
+    event_log, path = log_and_path
+    event_log.append(valid_mapping(agent_id=8))
+    original_rows = event_log.list_quarantine()
+
+    assert len(original_rows) == 1
+
+    for statement in (
+        "UPDATE flywheel_quarantine SET reason_code = 'tampered'",
+        "DELETE FROM flywheel_quarantine",
+    ):
+        with sqlite3.connect(path) as connection:
+            with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+                connection.execute(statement)
+
+    rows = event_log.list_quarantine()
+    assert len(rows) == 1
+    assert rows == original_rows
+
+
 def test_replaying_the_same_event_100_times_is_idempotent(log_and_path):
     event_log, _ = log_and_path
     raw = valid_mapping()

--- a/tests/gep/test_flywheel_log.py
+++ b/tests/gep/test_flywheel_log.py
@@ -8,6 +8,15 @@ from gep.flywheel_event import canonical_event_bytes, event_from_mapping, hash_p
 from gep.flywheel_log import AppendReceipt, FlywheelEventLog
 
 
+class UnknownFingerprintValue:
+    pass
+
+
+class ExplosiveReprValue:
+    def __repr__(self):
+        raise RuntimeError("repr must not run")
+
+
 def valid_mapping(**overrides):
     payload = overrides.pop(
         "payload",
@@ -304,6 +313,42 @@ def test_quarantine_fingerprints_preserve_heterogeneous_mapping_key_types(tmp_pa
     assert len(rows) == 2
     assert {row["reason_code"] for row in rows} == {"invalid_schema"}
     assert len({row["fingerprint"] for row in rows}) == 2
+
+
+def test_unknown_class_instances_have_stable_quarantine_fingerprint(tmp_path):
+    path = tmp_path / "opaque-fingerprint.sqlite3"
+    event_log = FlywheelEventLog(path, registered_agent_ids={7})
+    first = valid_mapping()
+    first["unknown_input"] = UnknownFingerprintValue()
+    second = valid_mapping()
+    second["unknown_input"] = UnknownFingerprintValue()
+
+    try:
+        first_receipt = event_log.append(first)
+        second_receipt = event_log.append(second)
+        rows = event_log.list_quarantine()
+    finally:
+        event_log.close()
+
+    assert first_receipt.status == second_receipt.status == "quarantined"
+    assert second_receipt == first_receipt
+    assert len(rows) == 1
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", rows[0]["fingerprint"])
+
+
+def test_unknown_object_with_failing_repr_is_quarantined(tmp_path):
+    path = tmp_path / "explosive-repr.sqlite3"
+    event_log = FlywheelEventLog(path, registered_agent_ids={7})
+    raw = valid_mapping()
+    raw["unknown_input"] = ExplosiveReprValue()
+
+    try:
+        receipt = event_log.append(raw)
+    finally:
+        event_log.close()
+
+    assert receipt.status == "quarantined"
+    assert receipt.reason_code == "invalid_schema"
 
 
 def test_quarantine_schema_and_rows_never_persist_raw_sensitive_input(tmp_path):

--- a/tests/gep/test_flywheel_log.py
+++ b/tests/gep/test_flywheel_log.py
@@ -287,6 +287,25 @@ def test_flywheel_event_errors_supply_quarantine_reason_codes(log_and_path):
     }
 
 
+def test_quarantine_fingerprints_preserve_heterogeneous_mapping_key_types(tmp_path):
+    path = tmp_path / "typed-fingerprint.sqlite3"
+    event_log = FlywheelEventLog(path, registered_agent_ids={7})
+    first = valid_mapping()
+    first["unknown_input"] = {1: "second", "1": "first"}
+    second = valid_mapping()
+    second["unknown_input"] = {1: "second", "1": "second"}
+
+    event_log.append(first)
+    event_log.append(second)
+
+    rows = event_log.list_quarantine()
+    event_log.close()
+
+    assert len(rows) == 2
+    assert {row["reason_code"] for row in rows} == {"invalid_schema"}
+    assert len({row["fingerprint"] for row in rows}) == 2
+
+
 def test_quarantine_schema_and_rows_never_persist_raw_sensitive_input(tmp_path):
     path = tmp_path / "safe-quarantine.sqlite3"
     event_log = FlywheelEventLog(path, registered_agent_ids={7})


### PR DESCRIPTION
## Summary

- add the strict `compass.flywheel.event.v1` episode envelope around `ExperiencePacket v0`
- persist canonical events and safe quarantine receipts in an immutable, idempotent SQLite journal
- add the thin `CompassS4AgentHarness` plus a pure deterministic `awaiting_verdict` reducer
- package the top-level `gep` modules in release wheels and smoke-test imports outside the source tree
- run GEP tests across Linux/macOS and Python 3.9/3.10/3.12 CI coverage

## Why

This is the first durable unit of the Compass externalized post-training flywheel:

`action -> ExperiencePacket -> immutable event log -> later verdict/policy/capsule events`

The PR deliberately stops before PoI ranking, capsule generation, route mutation, scheduling, or model training.

## Safety and correctness

- exact allowlists and runtime field types; unknown or malformed input fails closed
- canonical JSON plus SHA-256 payload/event hashes
- registered-agent admission, duplicate replay, source/episode conflict handling
- accepted and quarantine tables both reject UPDATE and DELETE
- quarantine stores only safe IDs, reason, fingerprint, and timestamp
- reducer rejects duplicate episode lineage instead of silently overwriting
- non-editable wheel smoke prevents editable-install false greens

## Verification

- `tests/gep`: 144 passed on Python 3.9, 3.10, and 3.13
- local CI-equivalent pytest set: 184 passed
- full Ruff: passed
- fresh-process SQLite restart replay: identical event/state hash, one event, `awaiting_verdict`
- wheel built, installed into an isolated venv, and imported from outside the repository
- final independent review: approved; no Critical/Important findings

## Non-goals

No daemon wiring, `ingest_obs`, PoI ranking, capsule generation, governance mutation, FDE/Feishu integration, robot execution, or model-weight training.